### PR TITLE
Drizzle: Enable snake casing by default

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -14,4 +14,4 @@ const globalForDb = globalThis as unknown as {
 const conn = globalForDb.conn ?? postgres(process.env.DATABASE_URL!);
 if (process.env.NODE_ENV !== "production") globalForDb.conn = conn;
 
-export const db = drizzle(conn, { schema });
+export const db = drizzle(conn, { schema, casing: "snake_case" });

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -22,13 +22,12 @@ export const session = createTable("session", {
   id: text().primaryKey(),
   expiresAt: timestamp().notNull(),
   token: text().notNull().unique(),
-  createdAt: timestamp().notNull(),
-  updatedAt: timestamp().notNull(),
   ipAddress: text(),
   userAgent: text(),
   userId: text()
     .notNull()
     .references(() => user.id),
+  ...timestamps,
 });
 
 export const account = createTable("account", {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -2,59 +2,62 @@ import { pgTableCreator, text, timestamp, boolean } from "drizzle-orm/pg-core";
 
 export const createTable = pgTableCreator((name) => `mail0_${name}`);
 
+// Helpers
+const timestamps = {
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+};
+
+// Tables
 export const user = createTable("user", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").notNull(),
-  image: text("image"),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
+  id: text().primaryKey(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  emailVerified: boolean().notNull(),
+  image: text(),
+  ...timestamps,
 });
 
 export const session = createTable("session", {
-  id: text("id").primaryKey(),
-  expiresAt: timestamp("expires_at").notNull(),
-  token: text("token").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
-  ipAddress: text("ip_address"),
-  userAgent: text("user_agent"),
-  userId: text("user_id")
+  id: text().primaryKey(),
+  expiresAt: timestamp().notNull(),
+  token: text().notNull().unique(),
+  createdAt: timestamp().notNull(),
+  updatedAt: timestamp().notNull(),
+  ipAddress: text(),
+  userAgent: text(),
+  userId: text()
     .notNull()
     .references(() => user.id),
 });
 
 export const account = createTable("account", {
-  id: text("id").primaryKey(),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  userId: text("user_id")
+  id: text().primaryKey(),
+  accountId: text().notNull(),
+  providerId: text().notNull(),
+  userId: text()
     .notNull()
     .references(() => user.id),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  idToken: text("id_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-  scope: text("scope"),
-  password: text("password"),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
+  accessToken: text(),
+  refreshToken: text(),
+  idToken: text(),
+  accessTokenExpiresAt: timestamp(),
+  refreshTokenExpiresAt: timestamp(),
+  scope: text(),
+  password: text(),
+  ...timestamps,
 });
 
 export const verification = createTable("verification", {
-  id: text("id").primaryKey(),
-  identifier: text("identifier").notNull(),
-  value: text("value").notNull(),
-  expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at"),
-  updatedAt: timestamp("updated_at"),
+  id: text().primaryKey(),
+  identifier: text().notNull(),
+  value: text().notNull(),
+  expiresAt: timestamp().notNull(),
+  ...timestamps,
 });
 
 export const earlyAccess = createTable("early_access", {
-  id: text("id").primaryKey(),
-  email: text("email").notNull().unique(),
-  createdAt: timestamp("created_at").notNull(),
-  updatedAt: timestamp("updated_at").notNull(),
+  id: text().primaryKey(),
+  email: text().notNull().unique(),
+  ...timestamps,
 });

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -8,4 +8,5 @@ export default {
   },
   out: "./db/migrations",
   tablesFilter: ["mail0_*"],
+  casing: "snake_case",
 } satisfies Config;


### PR DESCRIPTION
Quick PR to switch Drizzle ORM to snake_case by default. Here's the breakdown:

- **db/index.ts:** Added `{ casing: "snake_case" }` to the drizzle init.
- **drizzle.config.ts:** Set global casing to snake_case.
- **db/schema.ts:** Updated schema defs to match.

Should keep our DB columns consistent. Docs here: https://orm.drizzle.team/docs/sql-schema-declaration#camel-and-snake-casing