### PR TITLE
fix: background color of provider login buttons (#422)

### DIFF
--- a/apps/mail/app/(auth)/login/login-client.tsx
+++ b/apps/mail/app/(auth)/login/login-client.tsx
@@ -300,7 +300,7 @@ export function LoginClient({ providers, isProd }: LoginClientProps) {
                   <Button
                     key={provider.id}
                     onClick={() => handleProviderClick(provider)}
-                    className="border-input bg-background text-primary hover:bg-accent hover:text-accent-foreground h-12 w-full rounded-lg border-2 bg-black"
+                    className="border-input bg-background text-primary hover:bg-accent hover:text-accent-foreground h-12 w-full rounded-lg border-2"
                   >
                     {getProviderIcon(provider.id)}
                     Continue with {provider.name}


### PR DESCRIPTION
## Description

- Removed redundant `bg-black` class from OAuth provider login buttons since `bg-background` was already handling the background styling

---

## Type of Change

Please delete options that are not relevant.

- [x] 🎨 UI/UX improvement

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

**Dark mode**

https://github.com/user-attachments/assets/37069b84-ccca-4402-94f7-6d0663099466

**Light mode**

https://github.com/user-attachments/assets/f25b9e81-52a7-4932-bdf2-a324a5f3327d


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
