### PR TITLE
Remove shadow from `SettingsCard` and `MailCategoryTabs` component

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -565,7 +565,7 @@ function MailCategoryTabs({
 
       <div
         aria-hidden
-        className="absolute inset-0 z-10 overflow-hidden shadow-sm transition-[clip-path] duration-300 ease-in-out"
+        className="absolute inset-0 z-10 overflow-hidden transition-[clip-path] duration-300 ease-in-out"
         ref={containerRef}
       >
         <ul className="flex justify-center gap-1.5">

--- a/apps/mail/components/settings/settings-card.tsx
+++ b/apps/mail/components/settings/settings-card.tsx
@@ -16,7 +16,7 @@ export function SettingsCard({
   className,
 }: SettingsCardProps) {
   return (
-    <Card className={cn("w-full border-none bg-offsetLight px-0 dark:bg-offsetDark", className)}>
+    <Card className={cn("w-full border-none bg-offsetLight px-0 dark:bg-offsetDark shadow-none", className)}>
       <CardHeader className="px-0 pt-0">
         <CardTitle>{title}</CardTitle>
         {description && <CardDescription>{description}</CardDescription>}


### PR DESCRIPTION
## Description

- Fix #449
- Removed box-shadow  from `SettingsCard` and `MailCategoryTabs` component

---

## Type of Change

- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

## Testing Done

- [ ] Manual testing performed

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots/Recordings

![CleanShot 2025-03-15 at 19 50 47@2x](https://github.com/user-attachments/assets/381edc18-4ac2-4a24-b7a4-bd349e51bd07)

![CleanShot 2025-03-15 at 19 51 23@2x](https://github.com/user-attachments/assets/1a35f2c0-8fc5-4903-959a-d5b5ae78d61c)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated visual elements in the mail interface by removing subtle shadow effects, resulting in a flatter, more modern appearance across key components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->