### PR TITLE
Fix sidebar overflow

### DIFF
--- a/apps/mail/components/ui/app-sidebar.tsx
+++ b/apps/mail/components/ui/app-sidebar.tsx
@@ -82,7 +82,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						)}
 					</AnimatePresence>
 				</SidebarHeader>
-				<SidebarContent className="py-0 pt-0">
+				<SidebarContent className="overflow-x-hidden py-0 pt-0">
 					<AnimatePresence mode="wait">
 						<motion.div
 							key={currentSection}


### PR DESCRIPTION
## Description

Fixes an overflow during the sidebar animation when opening settings.

Before

https://github.com/user-attachments/assets/b5a074da-c84f-4ba2-9064-e4246e9e5a85


After

https://github.com/user-attachments/assets/393a2c5f-0dc5-4be4-85e7-2c382d7e8edf


---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [x] Any dependent changes are merged and published

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
