### PR TITLE
fix(#413): use max of boundingRect and scrollHeight for email iframe …

### DIFF
--- a/apps/mail/components/mail/mail-iframe.tsx
+++ b/apps/mail/components/mail/mail-iframe.tsx
@@ -15,17 +15,29 @@ export function MailIframe({ html }: { html: string }) {
 
   const t = useTranslations();
 
+  const calculateAndSetHeight = () => {
+    if (!iframeRef.current?.contentWindow?.document.body) return;
+
+    const body = iframeRef.current.contentWindow.document.body;
+    const boundingRectHeight = body.getBoundingClientRect().height;
+    const scrollHeight = body.scrollHeight;
+
+    // Use the larger of the two values to ensure all content is visible
+    setHeight(Math.max(boundingRectHeight, scrollHeight));
+  };
+
   useEffect(() => {
     if (!iframeRef.current) return;
     const url = URL.createObjectURL(new Blob([iframeDoc], { type: "text/html" }));
     iframeRef.current.src = url;
     const handler = () => {
       if (iframeRef.current?.contentWindow?.document.body) {
-        const { height } = iframeRef.current.contentWindow.document.body.getBoundingClientRect();
-        setHeight(height);
+        calculateAndSetHeight();
         fixNonReadableColors(iframeRef.current.contentWindow.document.body);
       }
       setLoaded(true);
+      // Recalculate after a slight delay to catch any late-loading content
+      setTimeout(calculateAndSetHeight, 500);
     };
     iframeRef.current.onload = handler;
 


### PR DESCRIPTION
# Improved Email Iframe Height Calculation

## Description
This PR enhances the height calculation for mail iframes to ensure all content is visible. The change implements a more robust approach that compares both the bounding rectangle height and scroll height, using whichever is larger. This fixes issues where some email content was being cut off or not displaying properly.

---
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement

## Areas Affected
- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience

## Testing Done
- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)

## Security Considerations
- [x] No sensitive data is exposed

## Checklist
- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings

## Screenshots/Recordings
![423622212-9186b9de-c3bf-49cd-8b12-8b91e02032a7](https://github.com/user-attachments/assets/275a53a7-7e66-4bb8-9907-3976f9116f31)

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.*