### PR TITLE
Only show unsubscribe button if header is valid

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -12,14 +12,15 @@ import { BellOff, Check, ChevronDown, LoaderCircleIcon, Lock } from 'lucide-reac
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { handleUnsubscribe } from '@/lib/email-utils.client';
+import { getListUnsubscribeAction } from '@/lib/email-utils';
 import AttachmentsAccordion from './attachments-accordion';
+import { useEffect, useMemo, useState } from 'react';
 import AttachmentDialog from './attachment-dialog';
 import { useSummary } from '@/hooks/use-summary';
 import { TextShimmer } from '../ui/text-shimmer';
 import { type ParsedMessage } from '@/types';
 import { Separator } from '../ui/separator';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
 import { MailIframe } from './mail-iframe';
 import { Button } from '../ui/button';
 import { format } from 'date-fns';
@@ -118,6 +119,17 @@ const MailDisplay = ({ emailData, isMuted, index, demo }: Props) => {
   const [unsubscribed, setUnsubscribed] = useState(false);
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
+  const listUnsubscribeAction = useMemo(
+    () =>
+      emailData.listUnsubscribe
+        ? getListUnsubscribeAction({
+            listUnsubscribe: emailData.listUnsubscribe,
+            listUnsubscribePost: emailData.listUnsubscribePost,
+          })
+        : undefined,
+    [emailData.listUnsubscribe, emailData.listUnsubscribePost],
+  );
+
   const _handleUnsubscribe = async () => {
     setIsUnsubscribing(true);
     try {
@@ -160,7 +172,7 @@ const MailDisplay = ({ emailData, isMuted, index, demo }: Props) => {
                   <span className="text-muted-foreground flex grow-0 items-center gap-2 text-sm">
                     <span>{emailData?.sender?.email}</span>
 
-                    {!!emailData.listUnsubscribe && (
+                    {listUnsubscribeAction && (
                       <Dialog>
                         <DialogTrigger asChild>
                           <Button


### PR DESCRIPTION
## Description

We should only show the unsubscribe button if we are able to parse a valid action from the header.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [x] No sensitive data is exposed
- [x] Authentication checks are in place
- [x] Input validation is implemented
- [x] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [x] Any dependent changes are merged and published

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
