### PR TITLE
[Fix: 488] - Mark thread as read to update email status to read

### DIFF
--- a/apps/mail/app/api/driver/google.ts
+++ b/apps/mail/app/api/driver/google.ts
@@ -177,14 +177,37 @@ export const driver = async (config: IConfig): Promise<MailManager> => {
       }
     },
     markAsRead: async (id: string[]) => {
-      await gmail.users.messages.batchModify({
-        userId: "me",
-        requestBody: {
-          ids: id,
-          removeLabelIds: ["UNREAD"],
-        },
-      });
-    },
+			try {
+
+				if (id.length > 0) {
+					const threadResponse = await gmail.users.threads.get({
+						userId: 'me',
+						id: id[0],
+					});
+
+					const thread = threadResponse.data;
+
+					const messageIds =
+						thread.messages
+							?.map((message) => message.id)
+							.filter((id): id is string => id !== null && id !== undefined) || [];
+
+
+					if (messageIds.length > 0) {
+              await gmail.users.messages.batchModify({
+							userId: 'me',
+							requestBody: {
+								ids: messageIds,
+								removeLabelIds: ['UNREAD'],
+							},
+						});
+					}
+				}
+			} catch (error) {
+				console.error('Error marking messages as read:', error);
+        throw error
+			}
+		},
     markAsUnread: async (id: string[]) => {
       await gmail.users.messages.batchModify({
         userId: "me",


### PR DESCRIPTION
## Description

Threads weren't marked as read previously even after reading all the messages under the email. This was happening because we weren't marking all the messages under the email as read. I have added logic to remove "UNREAD" labels from all the messages to mark the email as read.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] User Interface/Experience
- [x] Development Workflow

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Security Considerations

None

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] Any dependent changes are merged and published

## Additional Notes

I couldn't see an option to mark emails as read in batches so currently I'm just picking up the first email and its messages and marking them as read. Once we have "select all" and "mark as read" feature up, we can extend the logic to get messages for all the email IDs and mark as read.

## Screenshots/Recordings

[screen-capture (47).webm](https://github.com/user-attachments/assets/dc2afaf7-0e66-4082-a8c1-c6a8538b9a14)



_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
