### PR TITLE
fix: show primary emails

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -575,7 +575,7 @@ const Categories = () => {
     {
       id: 'Primary',
       name: t('common.mailCategories.primary'),
-      searchValue: '',
+      searchValue: 'in:inbox category:primary',
       icon: <Inbox className="h-4 w-4" />,
       colors:
         'border-0 bg-gray-200 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400 dark:hover:bg-gray-800/70',


### PR DESCRIPTION
# Description

Modified the Primary category to 'in:inbox category:primary' 
to ensure the Primary view only shows the relevant emails

Previously the empty search value would show all emails regardless of category

Type of Change
[x] 🐛 Bug fix (non-breaking change which fixes an issue)

Areas Affected
[x] User Interface/Experience

Testing Done
[x] Manual testing performed (verified Primary tab now shows only primary inbox emails)

Security Considerations
[x] No sensitive data is exposed
[x] Authentication checks are in place

Checklist
[x] My code follows the project's style guidelines
[x] I have performed a self-review of my code

Additional Notes
This change ensures the Primary category filter works as intended by explicitly filtering for:

Emails in the inbox (in:inbox)
Emails marked as primary (category:primary)

