### PR TITLE
fix(mail-display): correct conditional rendering and adjust styling

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -266,7 +266,7 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
                             {emailData?.to?.map((t) => t.email).join(', ')}
                           </span>
                         </div>
-                        {emailData?.cc?.length > 0 && (
+                        {emailData?.cc && emailData.cc.length > 0 && (
                           <div className="flex">
                             <span className="w-24 text-end text-gray-500">
                               {t('common.mailDisplay.cc')}:
@@ -318,7 +318,7 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
               </div>
             </div>
             {data ? (
-              <div className="relative top-1">
+              <div className='relative -top-1'>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button size={'icon'} variant="ghost" className="rounded-md">


### PR DESCRIPTION
## Description

Ensure proper rendering of CC field by checking for existence of `emailData.cc` before accessing its length. Adjust the top positioning of the popover (AI resume button) container for better alignment.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [ ] Any dependent changes are merged and published

## Screenshots/Recordings
![image](https://github.com/user-attachments/assets/e7a99b45-08b0-403c-86de-03f250ddfcaa)
![image](https://github.com/user-attachments/assets/669c1cd1-305d-4bda-a5c9-6b2c406f709a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the display logic for additional email recipients so that the section appears only when relevant data is available.
- **Style**
	- Adjusted element positioning to enhance visual alignment in the email view interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->