### PR TITLE
toggle cc bcc in reply-composer, fix email Details popover onBlur event

### DIFF
--- a/apps/mail/actions/mail.ts
+++ b/apps/mail/actions/mail.ts
@@ -29,13 +29,19 @@ export const getMails = async ({
   }
 };
 
-export const getMail = async ({ id }: { id: string }) => {
+export const getMail = async ({ id }: { id: string }): Promise<ParsedMessage[]> => {
   if (!id) {
     throw new Error('Missing required fields');
   }
   try {
     const driver = await getActiveDriver();
-    return await driver.get(id);
+    const mailData = await driver.get(id);
+
+    if (!mailData) {
+      throw new Error('Mail data not found');
+    }
+
+    return mailData;
   } catch (error) {
     if (FatalErrors.includes((error as Error).message)) await deleteActiveConnection();
     console.error('Error getting mail:', error);

--- a/apps/mail/actions/send.ts
+++ b/apps/mail/actions/send.ts
@@ -14,14 +14,14 @@ export async function sendEmail({
   headers: additionalHeaders = {},
   threadId
 }: {
-    to: Sender[];
+  to: Sender[];
   subject: string;
   message: string;
   attachments: File[];
-    headers?: Record<string, string>;
-    cc?: Sender[];
-    bcc?: Sender[];
-    threadId?: string
+  headers?: Record<string, string>;
+  cc?: Sender[];
+  bcc?: Sender[];
+  threadId?: string
 }) {
   if (!to || !subject || !message) {
     throw new Error("Missing required fields");

--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -14,7 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { handleUnsubscribe } from '@/lib/email-utils.client';
 import { getListUnsubscribeAction } from '@/lib/email-utils';
 import AttachmentsAccordion from './attachments-accordion';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState, useRef } from 'react';
 import AttachmentDialog from './attachment-dialog';
 import { useSummary } from '@/hooks/use-summary';
 import { TextShimmer } from '../ui/text-shimmer';
@@ -102,15 +102,16 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
     url: string;
   }>(null);
   const [openDetailsPopover, setOpenDetailsPopover] = useState<boolean>(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const t = useTranslations();
 
   const { data } = demo
     ? {
-        data: {
-          content:
-            'This email talks about how Zero Email is the future of email. It is a new way to send and receive emails that is more secure and private.',
-        },
-      }
+      data: {
+        content:
+          'This email talks about how Zero Email is the future of email. It is a new way to send and receive emails that is more secure and private.',
+      },
+    }
     : useSummary(emailData.id);
 
   useEffect(() => {
@@ -133,9 +134,9 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
     () =>
       emailData.listUnsubscribe
         ? getListUnsubscribeAction({
-            listUnsubscribe: emailData.listUnsubscribe,
-            listUnsubscribePost: emailData.listUnsubscribePost,
-          })
+          listUnsubscribe: emailData.listUnsubscribe,
+          listUnsubscribePost: emailData.listUnsubscribePost,
+        })
         : undefined,
     [emailData.listUnsubscribe, emailData.listUnsubscribePost],
   );
@@ -157,8 +158,8 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
   return (
     <div className={cn('relative flex-1 overflow-hidden')} id={`mail-${emailData.id}`}>
       <div className="relative h-full overflow-y-auto">
-        <div 
-          className="flex flex-col gap-4 p-4 pb-2 transition-all duration-200 cursor-pointer" 
+        <div
+          className="flex flex-col gap-4 p-4 pb-2 transition-all duration-200 cursor-pointer"
           onClick={() => setIsCollapsed(!isCollapsed)}
         >
           <div className="flex items-start justify-between gap-4">
@@ -177,7 +178,7 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
                 <div className="flex items-center justify-start gap-2">
                   <span className="font-semibold">{emailData?.sender?.name}</span>
                   <span className="text-muted-foreground flex grow-0 items-center gap-2 text-sm">
-                      <span className="overflow-hidden text-ellipsis whitespace-nowrap min-w-0">{emailData?.sender?.email}</span>
+                    <span className="overflow-hidden text-ellipsis whitespace-nowrap min-w-0">{emailData?.sender?.email}</span>
 
                     {listUnsubscribeAction && (
                       <Dialog>
@@ -234,15 +235,20 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
                         className="h-auto p-0 text-xs underline hover:bg-transparent"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setOpenDetailsPopover(true);
+                          setOpenDetailsPopover(!openDetailsPopover);
                         }}
+                        ref={triggerRef}
                       >
                         {t('common.mailDisplay.details')}
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent
                       className="w-[420px] rounded-lg border p-3 shadow-lg"
-                      onBlur={() => setOpenDetailsPopover(false)}
+                      onBlur={(e) => {
+                        if (!triggerRef.current?.contains(e.relatedTarget)) {
+                          setOpenDetailsPopover(false);
+                        }
+                      }}
                     >
                       <div className="space-y-1 text-sm">
                         <div className="flex">
@@ -266,7 +272,17 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
                             {emailData?.to?.map((t) => t.email).join(', ')}
                           </span>
                         </div>
-                        {emailData?.cc?.length > 0 && (
+                        {emailData?.cc && emailData.cc.length > 0 && (
+                          <div className="flex">
+                            <span className="w-24 text-end text-gray-500">
+                              {t('common.mailDisplay.cc')}:
+                            </span>
+                            <span className="text-muted-foreground ml-3">
+                              {emailData?.cc?.map((t) => t.email).join(', ')}
+                            </span>
+                          </div>
+                        )}
+                        {emailData?.bcc && emailData.bcc.length > 0 && (
                           <div className="flex">
                             <span className="w-24 text-end text-gray-500">
                               {t('common.mailDisplay.cc')}:

--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -285,10 +285,10 @@ const MailDisplay = ({ emailData, isMuted, index, totalEmails, demo }: Props) =>
                         {emailData?.bcc && emailData.bcc.length > 0 && (
                           <div className="flex">
                             <span className="w-24 text-end text-gray-500">
-                              {t('common.mailDisplay.cc')}:
+                              {t('common.mailDisplay.bcc')}:
                             </span>
                             <span className="text-muted-foreground ml-3">
-                              {emailData?.cc?.map((t) => t.email).join(', ')}
+                              {emailData?.bcc?.map((t) => t.email).join(', ')}
                             </span>
                           </div>
                         )}

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -234,14 +234,14 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
   const ccEmails = watch('cc');
   const bccEmails = watch('bcc');
 
-  const handleAddEmail = (type: 'to' | 'cc' | 'bcc', value: string) => {
-    const trimmedEmail = value.trim().replace(/,$/, '');
-    const currentEmails = getValues(type);
-    if (trimmedEmail && !currentEmails.includes(trimmedEmail) && isValidEmail(trimmedEmail)) {
-      setValue(type, [...currentEmails, trimmedEmail]);
-      setValue(`${type}Input`, '');
-    }
-  };
+  // const handleAddEmail = (type: 'to' | 'cc' | 'bcc', value: string) => {
+  //   const trimmedEmail = value.trim().replace(/,$/, '');
+  //   const currentEmails = getValues(type);
+  //   if (trimmedEmail && !currentEmails.includes(trimmedEmail) && isValidEmail(trimmedEmail)) {
+  //     setValue(type, [...currentEmails, trimmedEmail]);
+  //     setValue(`${type}Input`, '');
+  //   }
+  // };
 
   const handleSendEmail = async (e?: React.MouseEvent<HTMLButtonElement>) => {
     if (e) {
@@ -275,16 +275,16 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
 
       const ccRecipients: Sender[] | undefined = showCc
         ? ccEmails.map((email) => ({
-            email,
-            name: email.split('@')[0] || 'User',
-          }))
+          email,
+          name: email.split('@')[0] || 'User',
+        }))
         : undefined;
 
       const bccRecipients: Sender[] | undefined = showBcc
         ? bccEmails.map((email) => ({
-            email,
-            name: email.split('@')[0] || 'User',
-          }))
+          email,
+          name: email.split('@')[0] || 'User',
+        }))
         : undefined;
 
       const messageId = originalEmail.messageId;
@@ -497,15 +497,15 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
   const isMessageEmpty =
     !getValues('messageContent') ||
     getValues('messageContent') ===
-      JSON.stringify({
-        type: 'doc',
-        content: [
-          {
-            type: 'paragraph',
-            content: [],
-          },
-        ],
-      });
+    JSON.stringify({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [],
+        },
+      ],
+    });
 
   // Check if form is valid for submission
   const isFormValid = !isMessageEmpty || attachments.length > 0;
@@ -701,7 +701,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               </span>
             </div>
           </div>
-          
+
           <RecipientInput
             type="to"
             value={toEmails}
@@ -711,7 +711,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
             }}
             placeholder={t('pages.createEmail.example')}
           />
-          
+
           {showCc && (
             <RecipientInput
               type="cc"
@@ -724,7 +724,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               inputRef={ccInputRef}
             />
           )}
-          
+
           {showBcc && (
             <RecipientInput
               type="bcc"
@@ -1026,7 +1026,10 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                setShowCc(true);
+                setShowCc(!showCc);
+                if (showCc) {
+                  setValue('cc', []);
+                }
                 setIsEditingRecipients(true);
                 setTimeout(() => {
                   ccInputRef.current?.focus();
@@ -1034,7 +1037,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               }}
               className="text-xs"
             >
-              Add Cc
+              {showCc ? 'Remove Cc' : 'Add Cc'}
             </Button>
             <Button
               type="button"
@@ -1043,7 +1046,10 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                setShowBcc(true);
+                setShowBcc(!showBcc);
+                if (showCc) {
+                  setValue('bcc', []);
+                }
                 setIsEditingRecipients(true);
                 setTimeout(() => {
                   bccInputRef.current?.focus();
@@ -1051,7 +1057,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
               }}
               className="text-xs"
             >
-              Add Bcc
+              {showBcc ? 'Remove Bcc' : 'Add Bcc'}
             </Button>
             <CloseButton onClick={toggleComposer} />
           </div>
@@ -1201,13 +1207,13 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
             </Popover>
             <div className='-left-5 relative group'>
               <Input
-              type="file"
-              id="attachment-input"
+                type="file"
+                id="attachment-input"
                 className='w-10 opacity-0'
                 onChange={handleAttachmentEvent}
-              multiple
-              accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
-            />
+                multiple
+                accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
+              />
               <Button variant={'outline'} size={'icon'} type='button' className='transition-transform group-hover:scale-90 scale-75 absolute top-0 left-0 rounded-full pointer-events-none'>
                 <Plus />
               </Button>

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -1047,7 +1047,7 @@ export default function ReplyCompose({ mode = 'reply' }: ReplyComposeProps) {
                 e.preventDefault();
                 e.stopPropagation();
                 setShowBcc(!showBcc);
-                if (showCc) {
+                if (showBcc) {
                   setValue('bcc', []);
                 }
                 setIsEditingRecipients(true);

--- a/apps/mail/locales/en.json
+++ b/apps/mail/locales/en.json
@@ -134,6 +134,7 @@
       "from": "From",
       "to": "To",
       "cc": "Cc",
+      "bcc":"Bcc",
       "date": "Date",
       "mailedBy": "Mailed-By",
       "signedBy": "Signed-By",

--- a/apps/mail/types/index.ts
+++ b/apps/mail/types/index.ts
@@ -43,6 +43,7 @@ export interface ParsedMessage {
   sender: Sender;
   to: Sender[];
   cc: Sender[] | null;
+  bcc: Sender[] | null;
   tls: boolean;
   listUnsubscribe?: string;
   listUnsubscribePost?: string;


### PR DESCRIPTION
1. Both cc and bcc buttons now toggleable in email reply-composer.

![msedge_ErjmEUc3FA](https://github.com/user-attachments/assets/543a4ef0-a9c3-4728-af7b-960d886eb1c8)

2. Fixed the bug clicking the email details popover trigger button when the content is open

![msedge_7CMw40Neai](https://github.com/user-attachments/assets/4dc7ab82-f39b-4e38-81ec-0af05ba19c68)

---

## Type of Change

Please delete options that are not relevant.

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [X] 🎨 UI/UX improvement
- [X] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [X] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [X] Manual testing performed

## Security Considerations

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] All tests pass locally

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
