### PR TITLE
Added hover state in dark mode for better visibility

### DIFF
--- a/apps/mail/app/api/og/home/route.tsx
+++ b/apps/mail/app/api/og/home/route.tsx
@@ -51,6 +51,9 @@ export async function GET() {
             Experience email the way you want with 0 - the first open source email app that puts
             your privacy and safety first.
           </div>
+          <div tw="text-[36px] text-center mt-10" style={{ fontFamily: 'light' }}>
+            Early Access Users: 12,000
+          </div>
           {/* <div tw="text-3xl rounded-xl mt-16 text-primary w-[16rem] flex items-center justify-center h-20">
             <span tw="mr-2 border-2 border-white w-full h-16 bg-white/20 rounded-lg flex items-center justify-center">
               Register Now

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -252,7 +252,7 @@ const Thread = memo(
             key={message.threadId ?? message.id}
             className={cn(
               'hover:bg-offsetLight hover:bg-primary/5 group relative flex cursor-pointer flex-col items-start overflow-clip rounded-lg border border-transparent px-4 py-3 text-left text-sm transition-all hover:opacity-100',
-              (isMailSelected || !message.unread && !['sent', 'archive', 'bin'].includes(folder)) && 'dark:opacity-50 opacity-80',
+              (isMailSelected || !message.unread && !['sent', 'archive', 'bin'].includes(folder)) && 'dark:opacity-50 opacity-80 dark:hover:opacity-80',
               (isMailSelected || isMailBulkSelected || isKeyboardFocused) &&
                 'border-border bg-primary/5 opacity-100',
               isKeyboardFocused && 'ring-primary/50 ring-2',


### PR DESCRIPTION

## Description

Added a hover in dark mode for better visibility previously is was not visible 

## What is Improved

Provides better visibility in dark mode on hove for messages that are already read 

## Present View

https://github.com/user-attachments/assets/0eaa1869-55d5-4a83-b0e3-8b52e8404443

## Improved View


https://github.com/user-attachments/assets/7228ba01-1a53-429e-8eae-2b497c72a310

## Changes

  - Added hover in dark mode 







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible text block showing "Early Access Users: 12,000" on the email app homepage.
- **Style**
  - Improved hover opacity styling for mail threads in dark mode, making them appear at 80% opacity on hover under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->