### PR TITLE
fix: update folder type from 'trash' to 'bin' in empty state component

### DIFF
--- a/apps/mail/components/mail/empty-state.tsx
+++ b/apps/mail/components/mail/empty-state.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/lib/utils';
 import { useMemo } from 'react';
 
 // Types for default inbox filters
-export type FolderType = 'inbox' | 'draft' | 'sent' | 'spam' | 'trash' | 'archive' | 'search';
+export type FolderType = 'inbox' | 'draft' | 'sent' | 'spam' | 'bin' | 'archive' | 'search';
 
 interface EmptyStateConfig {
   icon: LucideIcon;
@@ -65,7 +65,7 @@ const FOLDER_CONFIGS: FolderConfig = {
     title: 'No spam messages',
     description: 'Messages marked as spam will appear here',
   },
-  trash: {
+  bin: {
     icon: Trash2,
     title: 'Trash is empty',
     description: 'Deleted messages will appear here',


### PR DESCRIPTION
## Description

Fixed the Empty bin message 

---

## Type of Change

Incorrect message when bin is empty.


## Present Message
   - Your inbox is empty - this is the message is when bin is empty 
   
<img width="1413" alt="Screenshot 2025-04-16 at 4 06 56 AM" src="https://github.com/user-attachments/assets/719df1c5-de88-4438-8856-bd68cde8e768" />


## Updated Message
 - Trash is Empty - this is the message now when bin is empty

<img width="1413" alt="Screenshot 2025-04-16 at 4 13 19 AM" src="https://github.com/user-attachments/assets/1ddf06d0-c036-4ae1-8e8f-f7d68141984c" />


---
_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._