### PR TITLE
fix: random reply count in mail list

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -220,18 +220,22 @@ const Thread = memo(
                         ) : null}
                       </p>
                       <MailLabels labels={threadLabels} />
-                      {Math.random() > 0.5 ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="rounded-md border border-dotted px-[5px] py-[1px] text-xs opacity-70">
-                              {Math.random() * 10}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent className="px-1 py-0 text-xs">
-                            {t('common.mail.replies', { count: Math.random() * 10 })}
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : null}
+                      {Math.random() > 0.5 &&
+                        (() => {
+                          const count = Math.floor(Math.random() * 10) + 1;
+                          return (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="rounded-md border border-dotted px-[5px] py-[1px] text-xs opacity-70">
+                                  {count}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent className="px-1 py-0 text-xs">
+                                {t('common.mail.replies', { count })}
+                              </TooltipContent>
+                            </Tooltip>
+                          );
+                        })()}
                     </div>
                     {latestMessage.receivedOn ? (
                       <p


### PR DESCRIPTION
## Description

- Fixed the random reply count display logic in `mail-list.tsx` to:
  - Dsiplay integer-based (1~10) reply count instead of floating point
  - Maintain consistent count between tooltip trigger and content

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

**Before**

![CleanShot 2025-04-18 at 11 37 16@2x](https://github.com/user-attachments/assets/2865b7f4-1ef8-4694-9f3b-480d93761583)


**After**

![CleanShot 2025-04-18 at 11 36 08@2x](https://github.com/user-attachments/assets/780d22e0-8afe-482d-bb79-ca6a52dca01e)


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
