### PR TITLE
fix: Update email counts in sidebar after sending

### DIFF
--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -37,6 +37,7 @@ import { toast } from 'sonner';
 import * as React from 'react';
 import Editor from './editor';
 import './prosemirror.css';
+import { useStats } from '@/hooks/use-stats';
 
 const MAX_VISIBLE_ATTACHMENTS = 12;
 
@@ -115,6 +116,7 @@ export function CreateEmail({
 
   const { data: session } = useSession();
   const { data: connections } = useConnections();
+  const { mutate: mutateStats } = useStats();
 
   const activeAccount = React.useMemo(() => {
     if (!session) return null;
@@ -296,7 +298,11 @@ export function CreateEmail({
     setHasUnsavedChanges(true);
   }, [messageContent]);
 
-  const handleSendEmail = async () => {
+  const handleSendEmail = async (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
+
     if (!toEmails.length) {
       toast.error('Please enter at least one recipient email address');
       return;
@@ -337,6 +343,8 @@ export function CreateEmail({
       } else {
         console.log(posthog.capture('Create Email Sent'));
       }
+
+      mutateStats();
 
       setIsLoading(false);
       toast.success(t('pages.createEmail.emailSentSuccessfully'));

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -50,6 +50,7 @@ import { Sender } from '@/types';
 import { toast } from 'sonner';
 import type { z } from 'zod';
 import React from 'react';
+import { useStats } from '@/hooks/use-stats';
 
 // Utility function to check if an email is a noreply address
 const isNoReplyAddress = (email: string): boolean => {
@@ -255,6 +256,8 @@ export default function ReplyCompose() {
   //     [contactsList, bccInput, toEmails, ccEmails, bccEmails],
   //   );
 
+  const { mutate: mutateStats } = useStats();
+
   const handleSendEmail = async (values: FormData) => {
     if (!emailData) return;
     try {
@@ -329,7 +332,10 @@ export default function ReplyCompose() {
           'Thread-Id': threadId ?? '',
         },
         threadId,
-      }).then(() => mutate());
+      }).then(() => {
+        mutate();
+        mutateStats();
+      });
 
       if (ccRecipients && bccRecipients) {
         posthog.capture('Reply Email Sent with CC and BCC');


### PR DESCRIPTION
Fixes #727

This PR addresses two issues related to email counts displayed in the sidebar:

1.  **Sent Count Not Updating (Fixes #727):** After successfully sending an email using the "Create Email" or "Reply/Forward" composer, the "Sent" count in the sidebar did not update automatically. This has been fixed by calling `mutateStats()` after a successful send operation in `create-email.tsx` and `reply-composer.tsx`, triggering a refetch of the sidebar statistics.

2.  **Missing Draft/Bin/Spam Counts:** The counts for emails in the Drafts, Bin (Trash), and Spam folders were not being displayed correctly (often showing 0) in the sidebar. This was because the count function in the Google driver (google.ts) previously used the threadsUnread value from the Gmail API for determining counts. However, for system labels like SENT, DRAFT, TRASH, and SPAM, the threadsUnread value is typically 0. The correct count reflecting the number of items in these folders is found in the threadsTotal property, as seen in API responses:

```json
{
  id: 'SENT', name: 'SENT', type: 'system',
  messagesTotal: 5, messagesUnread: 0,
  threadsTotal: 4, threadsUnread: 0 // <- threadsUnread is 0, threadsTotal is correct
}
```

## Type of Change

- [x] 🐛 API -> Get gmail count info.
- [x] 🎨 Invalidate the count on create and reply.
## Areas Affected

- Email Integration (Gmail, IMAP, etc.) (Refers to the change in google.ts)


## Checklist


- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
