### PR TITLE
Fix attachment preview gets cut off in popover 

### DIFF
--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -784,7 +784,7 @@ export function CreateEmail({
                             </p>
                           </div>
                           <Separator />
-                          <div className="touch-auto overflow-y-auto overflow-x-hidden overscroll-contain px-1 py-1">
+                          <div className="touch-auto overflow-y-auto  max-h-[40vh] overflow-x-hidden overscroll-contain px-1 py-1">
                             <div className="grid grid-cols-2 gap-2">
                               {attachments.map((file, index) => (
                                 <div


### PR DESCRIPTION
## Attachment preview gets cut off when selecting multiple files

### Before 
<img width="1440" alt="Screenshot 2025-04-25 at 4 30 12 AM" src="https://github.com/user-attachments/assets/843b2688-e670-4175-b6be-8ff92bacc48b" />

## 

### After 
https://github.com/user-attachments/assets/149d229d-e871-4209-9396-f8a3a69fcf63


