### PR TITLE
Add sendDraft method to Gmail driver and MailManager interface

### DIFF
--- a/apps/mail/actions/send.ts
+++ b/apps/mail/actions/send.ts
@@ -14,6 +14,7 @@ export async function sendEmail({
   headers: additionalHeaders = {},
   threadId,
   fromEmail,
+  draftId,
 }: {
   to: Sender[];
   subject: string;
@@ -24,6 +25,7 @@ export async function sendEmail({
   bcc?: Sender[];
   threadId?: string;
   fromEmail?: string;
+  draftId?: string;
 }) {
   if (!to || !subject || !message) {
     throw new Error('Missing required fields');
@@ -43,7 +45,7 @@ export async function sendEmail({
     },
   });
 
-  await driver.create({
+  const emailData = {
     subject,
     to,
     message,
@@ -53,7 +55,13 @@ export async function sendEmail({
     bcc,
     threadId,
     fromEmail,
-  });
+  };
+
+  if (draftId) {
+    await driver.sendDraft(draftId, emailData);
+  } else {
+    await driver.create(emailData);
+  }
 
   return { success: true };
 }

--- a/apps/mail/app/api/driver/google.ts
+++ b/apps/mail/app/api/driver/google.ts
@@ -836,8 +836,16 @@ export const driver = async (config: IConfig): Promise<MailManager> => {
       return withErrorHandler(
         'sendDraft',
         async () => {
+          const { raw } = await parseOutgoing(data);
           await gmail.users.drafts.send({
             userId: 'me',
+            requestBody: {
+              id: draftId,
+              message: {
+                raw,
+                id: draftId,
+              },
+            },
           });
         },
         { draftId, data },

--- a/apps/mail/app/api/driver/google.ts
+++ b/apps/mail/app/api/driver/google.ts
@@ -832,6 +832,17 @@ export const driver = async (config: IConfig): Promise<MailManager> => {
         { threadIds, options },
       );
     },
+    sendDraft: async (draftId: string, data: IOutgoingMessage) => {
+      return withErrorHandler(
+        'sendDraft',
+        async () => {
+          await gmail.users.drafts.send({
+            userId: 'me',
+          });
+        },
+        { draftId, data },
+      );
+    },
     getDraft: async (draftId: string) => {
       return withErrorHandler(
         'getDraft',

--- a/apps/mail/app/api/driver/types.ts
+++ b/apps/mail/app/api/driver/types.ts
@@ -10,6 +10,7 @@ export interface IGetThreadResponse {
 export interface MailManager {
   get(id: string): Promise<IGetThreadResponse>;
   create(data: IOutgoingMessage): Promise<any>;
+  sendDraft(id: string, data: IOutgoingMessage): Promise<any>;
   createDraft(data: any): Promise<any>;
   getDraft: (id: string) => Promise<any>;
   listDrafts: (q?: string, maxResults?: number, pageToken?: string) => Promise<any>;

--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -335,7 +335,7 @@ export function CreateEmail({
       // Use the selected from email or the first alias (or default user email)
       const fromEmail = selectedFromEmail || (aliases?.[0]?.email ?? userEmail);
 
-      await sendEmail({
+      const emailData = {
         to: toEmails.map((email) => ({ email, name: email.split('@')[0] || email })),
         cc: showCc
           ? ccEmails.map((email) => ({ email, name: email.split('@')[0] || email }))
@@ -347,7 +347,13 @@ export function CreateEmail({
         message: messageContent,
         attachments: attachments,
         fromEmail: fromEmail,
-      });
+      };
+
+      if (draftId) {
+        await sendEmail({ ...emailData, draftId });
+      } else {
+        await sendEmail(emailData);
+      }
 
       // Track different email sending scenarios
       if (showCc && showBcc) {
@@ -379,6 +385,8 @@ export function CreateEmail({
       setResetEditorKey((prev) => prev + 1);
 
       setHasUnsavedChanges(false);
+      // Clear the draftId after successful send
+      setDraftId(null);
     } catch (error) {
       console.error('Error sending email:', error);
       setIsLoading(false);
@@ -784,7 +792,7 @@ export function CreateEmail({
                             </p>
                           </div>
                           <Separator />
-                          <div className="touch-auto overflow-y-auto  max-h-[40vh] overflow-x-hidden overscroll-contain px-1 py-1">
+                          <div className="max-h-[40vh] touch-auto overflow-y-auto overflow-x-hidden overscroll-contain px-1 py-1">
                             <div className="grid grid-cols-2 gap-2">
                               {attachments.map((file, index) => (
                                 <div


### PR DESCRIPTION
fixes: https://feedback.0.email/p/sent-emails-remain-in-drafts-folder

sending a draft thats already in gmail requires us to use `user.drafts.send` instead of `user.messages.send`

this pr fixes this so if there is a draftId then it will send the draft