### PR TITLE
Clear search when "inbox" clicked

### DIFF
--- a/apps/mail/components/mail/search-bar.tsx
+++ b/apps/mail/components/mail/search-bar.tsx
@@ -91,7 +91,7 @@ type SearchForm = {
 
 export function SearchBar() {
   // const [popoverOpen, setPopoverOpen] = useState(false);
-  const [, setSearchValue] = useSearchValue();
+  const [searchValue, setSearchValue] = useSearchValue();
   const [isSearching, setIsSearching] = useState(false);
   const pathname = usePathname();
 
@@ -117,6 +117,14 @@ export function SearchBar() {
   });
 
   const q = form.watch('q');
+  
+  // Monitor changes to searchValue and update form accordingly
+  useEffect(() => {
+    // If searchValue is empty but the input isn't, clear the input
+    if (!searchValue.value && q) {
+      form.setValue('q', '');
+    }
+  }, [searchValue, q, form]);
 
   useEffect(() => {
     if (pathname !== '/mail/inbox') {

--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -232,6 +232,20 @@ export function NavMain({ items }: NavMainProps) {
     });
   };
 
+  // Function to reset search when clicking on Inbox
+  const handleResetSearch = useCallback(() => {
+    // Only reset if there's an active search
+    if (searchValue.value || searchValue.highlight || searchValue.folder) {
+      setSearchValue({
+        value: '',
+        highlight: '',
+        folder: '',
+        isLoading: false,
+        isAISearching: false,
+      });
+    }
+  }, [setSearchValue, searchValue]);
+
   return (
     <SidebarGroup className={`${state !== 'collapsed' ? '' : 'mt-1'} space-y-2.5 py-0`}>
       <SidebarMenu>
@@ -258,6 +272,7 @@ export function NavMain({ items }: NavMainProps) {
                     href={getHref(item)}
                     target={item.target}
                     title={item.title}
+                    onClick={item.id === 'inbox' ? handleResetSearch : item.onClick}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Description

Issue: https://feedback.0.email/p/when-i-click-inbox-in-the-sidebar-it-should-clear

Fix:
Clicking "inbox" in sidebar clears search params

---

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
