### PR TITLE
fix: allow attachments to wrap

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -761,7 +761,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo }: Props) => {
                 </div>
               )}
               {emailData?.attachments && emailData?.attachments.length > 0 ? (
-                <div className="mb-4 flex items-center gap-2 pt-4 px-4">
+                <div className="mb-4 flex items-center flex-wrap gap-2 pt-4 px-4">
                   {emailData?.attachments.map((attachment, index) => (
                     <div key={index}>
                       <button


### PR DESCRIPTION
## Description

Applied `flex-wrap` to the attachment container to prevent layout issues when multiple attachments are present, improving display on both mobile and desktop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

## Testing Done

- [x] Cross-browser testing
- [x] Mobile responsiveness verified

## Screenshots

![image](https://github.com/user-attachments/assets/71d79b89-e028-4f33-a177-94ec28645f2b)

![image](https://github.com/user-attachments/assets/8ee2b6c9-20a6-4731-a7e9-1fd6423636a6)

Closes #833