### PR TITLE
fix: Category button visibility issue in light mode

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -503,13 +503,13 @@ export const Categories = () => {
       id: 'Important',
       name: t('common.mailCategories.important'),
       searchValue: 'is:important',
-      icon: <Lightning className={cn('fill-white dark:fill-white')} />,
+      icon: <Lightning className={cn('fill-current')} />,
     },
     {
       id: 'All Mail',
       name: 'All Mail',
       searchValue: 'is:inbox',
-      icon: <Mail className={cn('fill-white dark:fill-white')} />,
+      icon: <Mail className={cn('fill-current')} />,
       colors:
         'border-0 bg-[#006FFE] text-white dark:bg-[#006FFE] dark:text-white dark:hover:bg-[#006FFE]/90',
     },
@@ -517,25 +517,25 @@ export const Categories = () => {
       id: 'Personal',
       name: t('common.mailCategories.personal'),
       searchValue: 'is:personal',
-      icon: <User className={cn('fill-white dark:fill-white')} />,
+      icon: <User className={cn('fill-current')} />,
     },
     {
       id: 'Updates',
       name: t('common.mailCategories.updates'),
       searchValue: 'is:updates',
-      icon: <Bell className={cn('fill-white dark:fill-white')} />,
+      icon: <Bell className={cn('fill-current')} />,
     },
     {
       id: 'Promotions',
       name: 'Promotions',
       searchValue: 'is:promotions',
-      icon: <Tag className={cn('fill-white dark:fill-white')} />,
+      icon: <Tag className={cn('fill-current')} />,
     },
     {
       id: 'Unread',
       name: 'Unread',
       searchValue: 'is:unread',
-      icon: <ScanEye className={cn('h-4 w-4 fill-white dark:fill-white')} />,
+      icon: <ScanEye className={cn('h-4 w-4 fill-current')} />,
     },
   ];
 };
@@ -603,7 +603,7 @@ function CategorySelect({ isMultiSelectMode }: { isMultiSelectMode: boolean }) {
               'flex h-8 items-center justify-center gap-1 overflow-hidden rounded-md border transition-all duration-300 ease-out dark:border-none',
               isSelected
                 ? cn('flex-1 border-none px-3 text-white', bgColor)
-                : 'w-8 bg-white hover:bg-gray-100 dark:bg-[#313131] dark:hover:bg-[#313131]/80',
+                : 'w-8 bg-white text-black hover:bg-gray-100 dark:bg-[#313131] dark:text-white dark:hover:bg-[#313131]/80',
             )}
             tabIndex={isOverlay ? -1 : undefined}
           >


### PR DESCRIPTION
## Description
Fixed an issue with icon visibility in light mode where category icons were using white fill regardless of the theme, making them difficult to see on light backgrounds when not selected. Changed icons to use black in light mode for unselected state while maintaining white for selected state and dark mode.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected
- [x] User Interface/Experience

## Testing Done
- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes
The fix uses `fill-current` class to make icons inherit text color from parent elements, creating a more accessible and consistent UI in both light and dark themes.

Here's the video of the representing the changes :

https://github.com/user-attachments/assets/8940f903-c366-4c8b-861c-f47742889ac9



*By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved icon and button color styling for mail categories to ensure consistent appearance in light and dark themes. Icons now inherit the current text color, and category buttons display appropriate text colors based on theme and selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->