### PR TITLE
Optimized Dockerfile for lighter docker image and faster build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+LICENSE
+ROADMAP.md
+tunnel.sh
+README.md
+.gitignore
+.husky
+.github
+.devcontainer
+.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,54 @@
-FROM oven/bun:canary
+# Use the latest Bun canary image for access to latest features and performance improvements
+FROM oven/bun:canary AS base
 
+# Set working directory inside the container
 WORKDIR /app
 
-# Install turbo globally
+# Install global CLI tools for monorepo management and frontend framework
 RUN bun install -g next turbo
 
-
+# Pre-copy lockfiles and monorepo config to leverage Docker layer caching during dependency resolution
 COPY package.json bun.lock turbo.json ./
 
+# Prepare directory structure for scoped dependency installs
 RUN mkdir -p apps packages
 
+# Copy only the relevant package manifests to enable selective installation and caching
 COPY apps/*/package.json ./apps/
 COPY packages/*/package.json ./packages/
 COPY packages/tsconfig/ ./packages/tsconfig/
 
+# Install dependencies for the monorepo. This step benefits from above caching strategy.
 RUN bun install
 
+# Copy the rest of the codebase into the container
 COPY . .
 
-# Installing with full context. Prevent missing dependencies error. 
+# Run `bun install` again in case any additional dependencies are introduced after full source copy
 RUN bun install
 
+# Build all apps/packages via defined turbo pipeline
+RUN bun run build
 
-RUN bun run build 
+# Use a smaller, stable Bun Alpine image for the production stage to minimize final image size
+FROM oven/bun:1.2.11-alpine AS production
 
+# Set working directory in production image
+WORKDIR /app
+
+# Copy fully built app from build stage
+COPY --from=base /app /app
+
+# Set production environment variables
 ENV NODE_ENV=production
+ENV NODE_OPTIONS=--no-experimental-fetch 
 
-# Resolve Nextjs TextEncoder error.
-ENV NODE_OPTIONS=--no-experimental-fetch
+# Add custom entrypoint script and ensure it is executable
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
+# Expose application port
 EXPOSE 3000
 
-CMD ["bun", "run", "start", "--host", "0.0.0.0"]
+# Define container entrypoint script (e.g., to run DB migrations, start server, etc.)
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/apps/mail/package.json
+++ b/apps/mail/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "dev:turbo": "next dev",
-    "build": "next build",
+    "build": "next build --turbo",
     "start": "next start",
     "lint": "eslint . --cache --cache-location ./node_modules/.cache/eslint",
     "scripts": "bun run ./scripts/run.ts"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+bun run db:migrate
+
+echo "Starting the app..."
+bun run start --host "0.0.0.0"


### PR DESCRIPTION
## Description

#### 1. Optimized Dockerfile by using Multi-stage build process + lighter image for runtime (bun canary alpine, it's about 35MB in size)

> 
> Here is a comparison of size of the docker image built by the current dockerfile and the dockerfile this PR has:
> ![image](https://github.com/user-attachments/assets/ecb85d83-f396-4e5a-9175-0604ddf05321)

#### 2. Added `entrypoint.sh` because you might run into db issue shown in below image:

> ![image](https://github.com/user-attachments/assets/de166ca2-83ab-4369-b5c5-180d0fbc65d3)
> The fix is to run `db:migrate` before starting the app, so the `entrypoint.sh` script runs the `db:migrate` first then it will start the app with `--host "0.0.0.0"` to bind it to all network interfaces (otherwise the app won't be reachable from outside of the container)

#### 3. Added `--turbo` flag to the build script on  `/app/mail/package.json` to reduce build times. 

> Below are comparison of before and after adding the turbo flag:
> Before (~4 min):
> ![image](https://github.com/user-attachments/assets/ee9f575c-e6ff-4f58-8783-a19f0fcd9230)
> 
> After (~2 min)
> ![image](https://github.com/user-attachments/assets/56f2bfee-004a-46ae-9029-b1febdb00553)


#### 4. Added `.dockerignore` file to prevent unwanted files from added to the docker image.

---

## Type of Change
- [x] ⚡ Performance improvement

## Areas Affected
- [x] Deployment/Infrastructure

## Testing Done
- [x] Manual testing performed


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes
1. The build time and docker image sizes are tested on mac mini m2 pro.
2. I noticed slightly higher RAM & CPU usage during build after I added the `--turbo` flag but the build time is much faster
3. I have tested the dockerfile more than 10+ times and deployed it to a VPS using Coolify as well


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
