### PR TITLE
Disable ai summary when brainState is not enabled

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -52,6 +52,7 @@ import { Button } from '../ui/button';
 import { useQueryState } from 'nuqs';
 import { Badge } from '../ui/badge';
 import Image from 'next/image';
+import { useBrainState } from '../../hooks/use-summary';
 
 // Add formatFileSize utility function
 const formatFileSize = (size: number) => {
@@ -291,6 +292,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo }: Props) => {
   const { labels: threadLabels } = useThreadLabels(
     emailData.tags ? emailData.tags.map((l) => l.id) : [],
   );
+  const { data: brainState } = useBrainState();
 
   useEffect(() => {
     if (!demo) {
@@ -485,7 +487,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo }: Props) => {
                   })()}
                 </div>
               </div>
-              <AiSummary />
+              { brainState?.enabled && <AiSummary /> }
             </>
           )}
         </div>


### PR DESCRIPTION
## Disabled AISummary when AI not active

### Before
 - when opening mail on staging 
  
  <img width="1433" alt="Screenshot 2025-05-04 at 5 02 32 PM" src="https://github.com/user-attachments/assets/90658fa5-a10d-4caf-917f-d832d489b8a2" />
 
### After 
- when open mail on local
  
<img width="1433" alt="Screenshot 2025-05-04 at 5 03 17 PM" src="https://github.com/user-attachments/assets/bd408bfe-add0-41a0-a464-6ebbd9c374e8" />


## Reason 
  - Because brain is not deployable it will not throw any error while development
  
 