### PR TITLE
Fixed: Issue #881 - Enable Selection on AvatarFallback

### DIFF
--- a/apps/mail/app/(routes)/settings/connections/page.tsx
+++ b/apps/mail/app/(routes)/settings/connections/page.tsx
@@ -140,7 +140,7 @@ export default function ConnectionsPage() {
                           {t('pages.settings.connections.disconnectDescription')}
                         </DialogDescription>
                       </DialogHeader>
-                      <div className="flex justify-end gap-4">
+                      <div className="flex justify-end gap-4 mt-4">
                         <DialogClose asChild>
                           <Button variant="outline">
                             {t('pages.settings.connections.cancel')}

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -352,7 +352,7 @@ const Thread = memo(
               'hover:bg-offsetLight hover:bg-primary/5 group relative flex cursor-pointer flex-col items-start overflow-clip rounded-lg border border-transparent px-4 py-3 text-left text-sm transition-all hover:opacity-100',
 
               (isMailSelected || isMailBulkSelected || isKeyboardFocused) &&
-                'border-border bg-primary/5 opacity-100',
+              'border-border bg-primary/5 opacity-100',
               isKeyboardFocused && 'ring-primary/50 ring-2',
             )}
           >
@@ -447,6 +447,17 @@ const Thread = memo(
 
     if (demo) return demoContent;
 
+
+
+    const handleBulkSelect = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const threadId = latestMessage?.threadId ?? message.id;
+      setMail((prev: Config) => ({
+        ...prev,
+        bulkSelected: [...prev.bulkSelected, threadId],
+      }));
+    }
+
     const content =
       latestMessage && getThreadData ? (
         <div className="select-none py-1" onClick={onClick ? onClick(latestMessage) : undefined}>
@@ -458,7 +469,7 @@ const Thread = memo(
             className={cn(
               'hover:bg-offsetLight hover:bg-primary/5 group relative mx-[8px] flex cursor-pointer flex-col items-start rounded-[10px] border-transparent py-3 text-left text-sm transition-all hover:opacity-100',
               (isMailSelected || isMailBulkSelected || isKeyboardFocused) &&
-                'border-border bg-primary/5 opacity-100',
+              'border-border bg-primary/5 opacity-100',
               isKeyboardFocused && 'ring-primary/50',
               'relative',
             )}
@@ -557,32 +568,18 @@ const Thread = memo(
                   {isGroupThread ? (
                     <div
                       className="flex h-full w-full items-center justify-center rounded-full bg-[#FFFFFF] p-2 dark:bg-[#373737]"
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        const threadId = latestMessage.threadId ?? message.id;
-                        setMail((prev: Config) => ({
-                          ...prev,
-                          bulkSelected: [...prev.bulkSelected, threadId],
-                        }));
-                      }}
+                      onClick={handleBulkSelect}
                     >
                       <GroupPeople className="h-4 w-4" />
                     </div>
                   ) : (
                     <>
                       <AvatarImage
-                        onClick={(e: React.MouseEvent) => {
-                          e.stopPropagation();
-                          const threadId = latestMessage.threadId ?? message.id;
-                          setMail((prev: Config) => ({
-                            ...prev,
-                            bulkSelected: [...prev.bulkSelected, threadId],
-                          }));
-                        }}
+                        onClick={handleBulkSelect}
                         className="rounded-full bg-[#FFFFFF] dark:bg-[#373737]"
                         src={getEmailLogo(latestMessage.sender.email)}
                       />
-                      <AvatarFallback className="rounded-full bg-[#FFFFFF] font-bold text-[#9F9F9F] dark:bg-[#373737]">
+                      <AvatarFallback  onClick={handleBulkSelect} className="rounded-full bg-[#FFFFFF] font-bold text-[#9F9F9F] dark:bg-[#373737]">
                         {cleanName[0]?.toUpperCase()}
                       </AvatarFallback>
                     </>


### PR DESCRIPTION
## Description

Fixed : #881

Enable users to select conversation with FallbackAvatar for bulk operation.

Fallback initials now behave the same as avatar images in terms of selection and visual alignment, improving usability during bulk operations.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

## Testing Done

- [x] Manual testing performed  
Verified that both avatar images and fallback initials are now selectable for bulk actions. Confirmed alignment and styling consistency.

## Security Considerations

- [x] No sensitive data is exposed


## Checklist

- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review of my code  
- [x] My changes generate no new warnings  


https://github.com/user-attachments/assets/6104f946-133e-4250-a566-903b8df18ead

