### PR TITLE
fix: email filters persisting in URL when navigating between mail folders

### DIFF
--- a/apps/mail/components/mail/search-bar.tsx
+++ b/apps/mail/components/mail/search-bar.tsx
@@ -1,6 +1,6 @@
 import { parseNaturalLanguageSearch, parseNaturalLanguageDate } from '@/lib/utils';
 import { useSearchValue } from '@/hooks/use-search-value';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { type DateRange } from 'react-day-picker';
 import { Input } from '@/components/ui/input';
 import { usePathname } from 'next/navigation';
@@ -30,6 +30,7 @@ export function SearchBar() {
   const [, setSearchValue] = useSearchValue();
   const [isSearching, setIsSearching] = useState(false);
   const pathname = usePathname();
+  const prevPathRef = useRef(pathname);
 
   const form = useForm<SearchForm>({
     defaultValues: {
@@ -55,10 +56,11 @@ export function SearchBar() {
   const q = form.watch('q');
 
   useEffect(() => {
-    if (pathname !== '/mail/inbox') {
+    if (pathname !== prevPathRef.current && pathname.startsWith('/mail/')) {
       resetSearch();
     }
-  }, [pathname]);
+    prevPathRef.current = pathname;
+  }, [pathname, resetSearch]);
 
   const submitSearch = useCallback(
     async (data: SearchForm) => {


### PR DESCRIPTION
## Description

- closes #785 
- When a user applied email filters in the Inbox and then navigated to other folders like Sent, Spam, or any Label folder, these filters were not cleared from the URL.
- This PR ensures that filters are reset when navigating between any mail folders, not just when navigating away from the inbox.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

N/A

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
