### PR TITLE
fix: email visibility issue when moving between folders

### DIFF
--- a/apps/mail/hooks/driver/use-move-to.ts
+++ b/apps/mail/hooks/driver/use-move-to.ts
@@ -9,6 +9,7 @@ import { useQueryState } from 'nuqs';
 import { useState } from 'react';
 import { useAtom } from 'jotai';
 import { toast } from 'sonner';
+import { useTRPC } from '@/providers/query-provider';
 
 const useMoveTo = () => {
   const t = useTranslations();
@@ -20,6 +21,7 @@ const useMoveTo = () => {
   const [, setFocusedIndex] = useAtom(focusedIndexAtom);
   const [, setThreadId] = useQueryState('threadId');
   const [, setActiveReplyId] = useQueryState('activeReplyId');
+  const trpc = useTRPC();
 
   const getCopyByDestination = (to?: MoveThreadOptions['destination']) => {
     switch (to) {
@@ -78,6 +80,7 @@ const useMoveTo = () => {
       finally: async () => {
         setIsLoading(false);
         await Promise.all([refetchThreads(), refetchStats()]);
+        trpc.mail.listThreads.invalidate({ folder: destination });
         for (const threadId of threadIds) {
           deleteFromQueue(threadId);
         }


### PR DESCRIPTION
## Description

- When moving an email from one folder to another, the email wasn't immediately visible in the destination folder without a page refresh.
  - This was because React Query's default invalidation only triggers refetches for "active" queries, and the destination folder's query wasn't active at the time of invalidation.
- This PR modifies the `useMoveTo` hook to invalidate the query for the destination folder after a move operation, ensuring that when a user navigates to the destination folder, the query is marked as stale and will be automatically refetched, making the moved email immediately visible without requiring a page refresh.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

N/A

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
