### PR TITLE
style(ui): increase max-width of email display in nav-user after gauge was removed

### DIFF
--- a/apps/mail/components/ui/nav-user.tsx
+++ b/apps/mail/components/ui/nav-user.tsx
@@ -531,7 +531,7 @@ export function NavUser() {
                 <BadgeCheck className="h-4 w-4 text-white dark:text-[#141414]" fill="#1D9BF0" />
               )}
             </div>
-            <div className="max-w-[150px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]">
+            <div className="max-w-[200px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]">
               {activeAccount?.email || session.user.email}
             </div>
           </div>


### PR DESCRIPTION
### Fix the width of active email in sidebar
 - Before 

<img width="211" alt="Screenshot 2025-05-13 at 2 24 47 AM" src="https://github.com/user-attachments/assets/793e5d23-590b-4604-b826-0095e50c8bf4" />

- After
 
<img width="211" alt="Screenshot 2025-05-13 at 2 24 30 AM" src="https://github.com/user-attachments/assets/f44992de-b2cc-43cd-85d3-b916d5f77bff" />

