### PR TITLE
fix: add missing classes to favorite star

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -1035,7 +1035,7 @@ function getLabelIcon(label: string) {
     case 'notes':
       return <StickyNote className="h-3.5 w-3.5" />;
     case 'starred':
-      return <Star className="h-3.5 w-3.5" />;
+      return <Star className="h-3.5 w-3.5 fill-yellow-400 stroke-yellow-400" />;
     default:
       return null;
   }


### PR DESCRIPTION
## Description

I added the classes `fill-yellow-400 stroke-yellow-400` to the `Star` component which is invoked in `getLabelIcon` function from `mail-list.tsx` component.

This PR intent is to fix one of the issues described in #960 

---

## Type of Change

Please delete options that are not relevant.

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

Please check all that apply:

- [X] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [X] Manual testing performed
- [X] Mobile responsiveness verified (if UI changes)

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

[Screen Recording After changes](https://www.loom.com/share/edb382795c5442558d893a4ae02f9ca7?sid=5eab9018-8d15-4110-825e-40489a17b6e7)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
