### PR TITLE
fix: recreate query client properly if session changes

### DIFF
--- a/apps/mail/lib/constants.ts
+++ b/apps/mail/lib/constants.ts
@@ -8,7 +8,7 @@ export const SIDEBAR_WIDTH_ICON = '3rem';
 export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 export const BASE_URL = process.env.NEXT_PUBLIC_APP_URL;
 export const MAX_URL_LENGTH = 2000;
-export const CACHE_BURST_KEY = 'cache-burst:v0.0.1';
+export const CACHE_BURST_KEY = 'cache-burst:v0.0.2';
 
 export const emailProviders = [
   {

--- a/apps/mail/providers/query-provider.tsx
+++ b/apps/mail/providers/query-provider.tsx
@@ -66,14 +66,28 @@ export const makeQueryClient = (session: Session | null) =>
     },
   });
 
-let browserQueryClient: QueryClient | undefined = undefined;
+let browserQueryClient = {
+  queryClient: undefined,
+  session: null,
+} as {
+  queryClient: QueryClient | undefined;
+  session: Session | null;
+};
 
 const getQueryClient = (session: Session | null) => {
   if (typeof window === 'undefined') {
     return makeQueryClient(session);
   } else {
-    if (!browserQueryClient) browserQueryClient = makeQueryClient(session);
-    return browserQueryClient;
+    if (
+      !browserQueryClient.queryClient ||
+      !browserQueryClient.session ||
+      browserQueryClient.session.user.id !== session?.user.id ||
+      browserQueryClient.session.connectionId !== session?.connectionId
+    ) {
+      browserQueryClient.queryClient = makeQueryClient(session);
+      browserQueryClient.session = session;
+    }
+    return browserQueryClient.queryClient;
   }
 };
 


### PR DESCRIPTION
## Description

recreate query client properly if session data changes, so the cache is properly tied to the account

---

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [ ] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

Add screenshots or recordings here if applicable.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
