### PR TITLE
Fix: Autolabelling issue of not getting labels

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -150,7 +150,7 @@ const AutoLabelingSettings = () => {
           <Button
             disabled={isPending}
             onClick={() => {
-              updateLabels({ labels: labels.map((label) => label.id) }).then(() => {
+              updateLabels({ labels: labels.map((label) => label.text) }).then(() => {
                 setOpen(false);
                 toast.success('Labels updated successfully, Zero will start using them.');
               });


### PR DESCRIPTION
### Fix the auto labelling  issue

- When user refresh the page after saving the labels, getting numbers instead of name of labels

- Before
 
<img width="1159" alt="Screenshot 2025-05-14 at 3 40 22 AM" src="https://github.com/user-attachments/assets/76c1cc66-840d-4c55-879b-fe31d86bbada" />


- After
<img width="1159" alt="Screenshot 2025-05-14 at 3 42 28 AM" src="https://github.com/user-attachments/assets/d3d03328-c367-4e3b-93e1-7a2fe37e3175" />
