### PR TITLE
fix: add Not Found page for unmatched routes

### DIFF
--- a/apps/mail/app/(error)/not-found.tsx
+++ b/apps/mail/app/(error)/not-found.tsx
@@ -10,7 +10,7 @@ export function NotFound() {
   const t = useTranslations();
 
   return (
-    <div className="dark:bg-background flex w-full items-center justify-center bg-white text-center">
+    <div className="dark:bg-background flex w-full h-screen items-center justify-center bg-white text-center">
       <div className="flex-col items-center justify-center md:flex dark:text-gray-100">
         <div className="relative">
           <h1 className="text-muted-foreground/20 select-none text-[150px] font-bold">404</h1>

--- a/apps/mail/app/(routes)/mail/[folder]/page.tsx
+++ b/apps/mail/app/(routes)/mail/[folder]/page.tsx
@@ -26,7 +26,7 @@ export default async function MailPage({ params }: MailPageProps) {
   const { folder } = await params;
 
   if (!ALLOWED_FOLDERS.includes(folder)) {
-    return <NotFound />
+    return <NotFound />;
   }
 
   return <MailLayout />;

--- a/apps/mail/app/(routes)/mail/[folder]/page.tsx
+++ b/apps/mail/app/(routes)/mail/[folder]/page.tsx
@@ -2,6 +2,7 @@ import { MailLayout } from '@/components/mail/mail';
 import { authProxy } from '@/lib/auth-proxy';
 import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
+import NotFound from '@/app/not-found';
 
 interface MailPageProps {
   params: Promise<{
@@ -25,7 +26,7 @@ export default async function MailPage({ params }: MailPageProps) {
   const { folder } = await params;
 
   if (!ALLOWED_FOLDERS.includes(folder)) {
-    return <div>Invalid folder</div>;
+    return <NotFound />
   }
 
   return <MailLayout />;


### PR DESCRIPTION
## Description

This PR implements proper **404 Not Found** page handling for undefined or invalid subroutes under `/mail/*`.
Previously, navigating to paths like `/mail/xyz` rendered an unstyled `<div>`, resulting in a broken user experience.
With this update, such invalid routes now correctly render the styled 404 page.

Closes #1009

![image](https://github.com/user-attachments/assets/2f57f2f3-9b9e-45c9-8c4f-f201c35e26ae)


---

## Type of Change

* [x] 🎨 UI/UX improvement

---

## Areas Affected

* [x] User Interface/Experience

---

## Testing Done

* [x] Manual testing performed:

  * Visited `/mail/invalid` and verified that the styled 404 page appears.
* [x] Cross-browser testing (if UI changes)
* [x] Mobile responsiveness verified (if UI changes)

---

## Checklist

* [x] I have read the [[CONTRIBUTING](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md) document
* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in complex areas
* [ ] I have updated the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [ ] All tests pass locally
* [ ] Any dependent changes are merged and published

## Screenshots/Recordings

Included above.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the appearance of the "Not Found" page so it now occupies the full height of the screen.
  - Enhanced error handling for invalid mail folders by displaying a dedicated "Not Found" page instead of a plain error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->