### PR TITLE
fix: use `strokeWidth` property instead of `stroke-width`

### DIFF
--- a/apps/mail/components/icons/icons.tsx
+++ b/apps/mail/components/icons/icons.tsx
@@ -1522,7 +1522,7 @@ export const ThickCheck = ({ className }: { className?: string }) => (
     <path
       d="M0.666992 4L2.75033 6.08333L7.33366 1.5"
       stroke="white"
-      stroke-width="1.875"
+      strokeWidth="1.875"
     />
   </svg>
 );
@@ -1564,7 +1564,7 @@ export const PurpleThickCheck = ({ className }: { className?: string }) => (
     <path
       d="M0.666992 4L2.75033 6.08333L7.33366 1.5"
       stroke="#A586FF"
-      stroke-width="1.875"
+      strokeWidth="1.875"
     />
   </svg>
 );


### PR DESCRIPTION
## Description

Fixes a DOM warning for incorrect property usage.

## Screenshots/Recordings

![Screenshot 2025-05-19 at 10 31 04 PM](https://github.com/user-attachments/assets/926695ee-a89e-4550-b852-a0ecdd18b983)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
