### PR TITLE
fix: clear category query param on navigating outside inbox

### DIFF
--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -171,7 +171,7 @@ export function NavMain({ items }: NavMainProps) {
       }
 
       // Handle category links
-      if (category) {
+      if (item.id === "inbox" && category) {
         return `${item.url}?category=${encodeURIComponent(category)}`;
       }
 


### PR DESCRIPTION
## Description

Clears `category` query param on navigation outside inbox.

Closes #785 

---

## Type of Change

Please delete options that are not relevant.

🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Screenshots/Recordings


https://github.com/user-attachments/assets/9c05c713-1820-4f08-af9c-8c7d42dc5e3b



---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
