### PR TITLE
feat: add pricing dialog for connection limits

### DIFF
--- a/apps/mail/app/(routes)/settings/connections/page.tsx
+++ b/apps/mail/app/(routes)/settings/connections/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SettingsCard } from '@/components/settings/settings-card';
 import { AddConnectionDialog } from '@/components/connection/add';
+import { PricingDialog } from '@/components/ui/pricing-dialog';
 import { useSession, authClient } from '@/lib/auth-client';
 import { useConnections } from '@/hooks/use-connections';
 import { useTRPC } from '@/providers/query-provider';
@@ -19,11 +20,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useMutation } from '@tanstack/react-query';
 import { Trash, Plus, Unplug } from 'lucide-react';
 import { useThreads } from '@/hooks/use-threads';
+import { useBilling } from '@/hooks/use-billing';
 import { emailProviders } from '@/lib/constants';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Image from 'next/image';
 import { toast } from 'sonner';
 
@@ -35,6 +37,9 @@ export default function ConnectionsPage() {
   const trpc = useTRPC();
   const { mutateAsync: deleteConnection } = useMutation(trpc.connections.delete.mutationOptions());
   const [{ refetch: refetchThreads }] = useThreads();
+
+  const { customer: billingCustomer } = useBilling();
+  const [showPricingDialog, setShowPricingDialog] = useState(false);
 
   const disconnectAccount = async (connectionId: string) => {
     await deleteConnection(
@@ -51,6 +56,17 @@ export default function ConnectionsPage() {
     refetch();
     void refetchThreads();
   };
+
+  const isPro = useMemo(() => {
+    return (
+      billingCustomer &&
+      Array.isArray(billingCustomer.products) &&
+      billingCustomer.products.some(
+        (product: any) =>
+          product.id.includes('pro-example') || product.name.includes('pro-example'),
+      )
+    );
+  }, [billingCustomer]);
 
   return (
     <div className="grid gap-6">
@@ -199,17 +215,33 @@ export default function ConnectionsPage() {
           ) : null}
 
           <div className="flex items-center justify-start">
-            <AddConnectionDialog>
-              <Button
-                variant="outline"
-                className="group relative w-9 overflow-hidden transition-all duration-200 hover:w-full sm:hover:w-[32.5%]"
-              >
-                <Plus className="absolute left-2 h-4 w-4" />
-                <span className="whitespace-nowrap pl-7 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                  {t('pages.settings.connections.addEmail')}
-                </span>
-              </Button>
-            </AddConnectionDialog>
+            {isPro ? (
+              <AddConnectionDialog>
+                <Button
+                  variant="outline"
+                  className="group relative w-9 overflow-hidden transition-all duration-200 hover:w-full sm:hover:w-[32.5%]"
+                >
+                  <Plus className="absolute left-2 h-4 w-4" />
+                  <span className="whitespace-nowrap pl-7 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    {t('pages.settings.connections.addEmail')}
+                  </span>
+                </Button>
+              </AddConnectionDialog>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  className="group relative w-9 overflow-hidden transition-all duration-200 hover:w-full sm:hover:w-[32.5%]"
+                  onClick={() => setShowPricingDialog(true)}
+                >
+                  <Plus className="absolute left-2 h-4 w-4" />
+                  <span className="whitespace-nowrap pl-7 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    {t('pages.settings.connections.addEmail')}
+                  </span>
+                </Button>
+                <PricingDialog open={showPricingDialog} onOpenChange={setShowPricingDialog} />
+              </>
+            )}
           </div>
         </div>
       </SettingsCard>


### PR DESCRIPTION
## Description

This PR fixes an issue where free-tier users were able to bypass pricing plan restrictions by adding new email connections via `Settings > Connections`. The billing plan check was not implemented on that path, allowing users to add multiple connections.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] User Interface/Experience
- [x] Authentication/Authorization

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed
  - Verified that the pricing plan dialog now appears when adding a connection from `Settings > Connections` for free users.

## Security Considerations

For changes involving data or authentication:

- [x] No sensitive data is exposed
- [x] Authentication checks are in place

Closes #1018 