### PR TITLE
chore: add auto merge CI

### DIFF
--- a/.github/workflows/auto-merge-prod.yml
+++ b/.github/workflows/auto-merge-prod.yml
@@ -1,0 +1,42 @@
+name: Deploy Production
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # if the PR is approved by MrgSub, we auto rebase it on main
+  deploy-to-production:
+    runs-on: ubuntu-latest
+    name: Deploy Production
+    concurrency:
+      group: 'rebase-${{ github.event.pull_request.id }}'
+      cancel-in-progress: false
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'staging' && github.event.review.user.login == 'MrgSub' && github.event.review.state == 'approved'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'main'
+
+      - name: Rebase the main branch on staging
+        uses: martincostello/rebaser@v1
+        id: rebase
+        with:
+          branch: 'main'
+
+      - name: Error if rebase was not successful
+        if: ${{ steps.rebase.outputs.result != 'success' }}
+        run: |
+          echo "Rebase failed"
+          exit 1
+
+      - name: Push changes if rebase was successful
+        if: ${{ steps.rebase.outputs.result == 'success' }}
+        run: git push --force-with-lease origin main


### PR DESCRIPTION
### TL;DR

Added a GitHub workflow to automatically deploy to production when staging PRs are approved by MrgSub.

### What changed?

Created a new GitHub workflow file `.github/workflows/auto-merge-prod.yml` that:
- Triggers when a pull request is approved
- Checks if the PR is from staging to main and was approved by MrgSub
- Automatically rebases main on staging
- Pushes the changes to main if the rebase is successful

### How to test?

1. Create a PR from staging to main
2. Have the GitHub user MrgSub approve the PR
3. Verify that the workflow runs and successfully rebases main on staging

### Why make this change?

To streamline the deployment process to production by automating the merge from staging to main when approved by the designated reviewer. This reduces manual steps and potential human error during the deployment process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new automated workflow to deploy changes to production when specific pull requests are approved. This streamlines the release process and ensures only approved updates are merged and deployed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->