### PR TITLE
fix(ui): show tooltip below for first item | mail list

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -254,7 +254,7 @@ const Thread = memo(
                     />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent className="mb-1 bg-white dark:bg-[#1A1A1A]">
+                <TooltipContent className="mb-1 bg-white dark:bg-[#1A1A1A]" side={index === 0 ?'bottom' : 'top'}>
                   {displayStarred
                     ? t('common.threadDisplay.unstar')
                     : t('common.threadDisplay.star')}
@@ -271,7 +271,7 @@ const Thread = memo(
                     <ExclamationCircle className={cn(displayImportant ? '' : 'opacity-25')} />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent className="dark:bg-panelDark mb-1 bg-white">
+                <TooltipContent className="dark:bg-panelDark mb-1 bg-white"  side={index === 0 ?'bottom' : 'top'}>
                   {t('common.mail.toggleImportant')}
                 </TooltipContent>
               </Tooltip>
@@ -289,7 +289,7 @@ const Thread = memo(
                     <Archive2 className="fill-[#9D9D9D]" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent className="dark:bg-panelDark mb-1 bg-white">
+                <TooltipContent className="dark:bg-panelDark mb-1 bg-white"  side={index === 0 ?'bottom' : 'top'}>
                   {t('common.threadDisplay.archive')}
                 </TooltipContent>
               </Tooltip>
@@ -308,7 +308,7 @@ const Thread = memo(
                       <Trash className="fill-[#F43F5E]" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent className="dark:bg-panelDark mb-1 bg-white">
+                  <TooltipContent className="dark:bg-panelDark mb-1 bg-white"  side={index === 0 ?'bottom' : 'top'}>
                     {t('common.actions.Bin')}
                   </TooltipContent>
                 </Tooltip>


### PR DESCRIPTION


## Description
Fix tooltip position to appear below for first mail in list.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [ ] Any dependent changes are merged and published


## Screenshots/Recordings

BEFORE:
[Screencast from 2025-05-31 16-58-33.webm](https://github.com/user-attachments/assets/c6f42654-e2e7-475f-b7b0-10899259b1d4)



AFTER : 
[Screencast from 2025-05-31 16-59-36.webm](https://github.com/user-attachments/assets/8754c55b-5dbb-403a-93b9-cb54712c5012)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
