### PR TITLE
fix(i18n): fixed i18n support for previously untranslated fields (labels)

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -807,7 +807,7 @@ export const Categories = () => {
     },
     {
       id: 'All Mail',
-      name: 'All Mail',
+      name:  t('common.mailCategories.allMail'),
       searchValue: 'NOT is:draft (is:inbox OR (is:sent AND to:me))',
       icon: (
         <Mail
@@ -848,7 +848,7 @@ export const Categories = () => {
     },
     {
       id: 'Promotions',
-      name: 'Promotions',
+      name: t('common.mailCategories.promotions'),
       searchValue: 'is:promotions NOT is:sent NOT is:draft',
       icon: (
         <Tag
@@ -861,7 +861,7 @@ export const Categories = () => {
     },
     {
       id: 'Unread',
-      name: 'Unread',
+      name: t('common.mailCategories.unread'),
       searchValue: 'is:unread NOT is:sent NOT is:draft',
       icon: (
         <ScanEye


### PR DESCRIPTION

## Description

**some lables on the mail list were not translating on language change.**

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published


## Screenshots/Recordings

before:
[Screencast from 2025-05-31 22-41-17.webm](https://github.com/user-attachments/assets/23599666-fc56-4b44-a2a3-9058e5a3cb32)

after:

[Screencast from 2025-05-31 22-41-59.webm](https://github.com/user-attachments/assets/b0327898-b9ad-4543-aee9-826668ac4f5b)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
