### PR TITLE
fix:sidebar labels background

### DIFF
--- a/apps/mail/components/ui/sidebar-labels.tsx
+++ b/apps/mail/components/ui/sidebar-labels.tsx
@@ -37,8 +37,8 @@ const SidebarLabels = ({ data, activeAccount, stats }: Props) => {
 
   return (
     <div className="mr-0 flex-1 pr-0">
-      <div className="bg-background no-scrollbar relative -m-2 flex-1 overflow-auto">
-        <Tree className="bg-background rounded-md">
+      <div className="bg-background max-h-48 no-scrollbar relative -m-2 flex-1 overflow-auto">
+        <Tree className="bg-sidebar rounded-md">
           {(() => {
             if (!data) return null;
             const isMicrosoftAccount = activeAccount?.providerId === 'microsoft';


### PR DESCRIPTION
## Fix sidebar background

- update the max label height to 48 for better UI

https://github.com/user-attachments/assets/6f0cbf9d-a007-49e1-9e05-50cd57b8bfdd


- Before 

<img width="227" alt="Screenshot 2025-06-01 at 2 02 10 AM" src="https://github.com/user-attachments/assets/f056e45e-24b7-4cbc-a58b-f0d313c46283" />

- After 
 
<img width="227" alt="Screenshot 2025-06-01 at 2 01 58 AM" src="https://github.com/user-attachments/assets/971c728a-ccaa-4c6e-91ca-6aa36aeae971" />

