### PR TITLE
adds zero signature to emails

### DIFF
--- a/apps/mail/app/(routes)/settings/general/page.tsx
+++ b/apps/mail/app/(routes)/settings/general/page.tsx
@@ -28,8 +28,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { useSettings } from '@/hooks/use-settings';
 import { Globe, Clock, XIcon } from 'lucide-react';
 import { availableLocales } from '@/i18n/config';
-import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 import { useRevalidator } from 'react-router';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
@@ -133,6 +133,7 @@ export default function GeneralPage() {
       timezone: getBrowserTimezone(),
       dynamicContent: false,
       customPrompt: '',
+      zeroSignature: false,
     },
   });
 
@@ -239,6 +240,23 @@ export default function GeneralPage() {
                   <FormDescription>
                     {t('pages.settings.general.customPromptDescription')}
                   </FormDescription>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="zeroSignature"
+              render={({ field }) => (
+                <FormItem className="flex max-w-xl flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                  <div className="space-y-0.5">
+                    <FormLabel>{t('pages.settings.general.zeroSignature')}</FormLabel>
+                    <FormDescription>
+                      {t('pages.settings.general.zeroSignatureDescription')}
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
                 </FormItem>
               )}
             />

--- a/apps/mail/app/(routes)/settings/general/page.tsx
+++ b/apps/mail/app/(routes)/settings/general/page.tsx
@@ -133,7 +133,7 @@ export default function GeneralPage() {
       timezone: getBrowserTimezone(),
       dynamicContent: false,
       customPrompt: '',
-      zeroSignature: false,
+      zeroSignature: true,
     },
   });
 

--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -104,12 +104,15 @@ export function CreateEmail({
     // Use the selected from email or the first alias (or default user email)
     const fromEmail = aliases?.[0]?.email ?? userEmail;
 
+    const zeroSignature =
+      '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>';
+
     await sendEmail({
       to: data.to.map((email) => ({ email, name: email.split('@')[0] || email })),
       cc: data.cc?.map((email) => ({ email, name: email.split('@')[0] || email })),
       bcc: data.bcc?.map((email) => ({ email, name: email.split('@')[0] || email })),
       subject: data.subject,
-      message: data.message,
+      message: data.message + zeroSignature,
       attachments: await serializeFiles(data.attachments),
       fromEmail: userName.trim() ? `${userName.replace(/[<>]/g, '')} <${fromEmail}>` : fromEmail,
       draftId: draftId ?? undefined,

--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -6,6 +6,7 @@ import { useHotkeysContext } from 'react-hotkeys-hook';
 import { useTRPC } from '@/providers/query-provider';
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import { useSettings } from '@/hooks/use-settings';
 import { EmailComposer } from './email-composer';
 import { useSession } from '@/lib/auth-client';
 import { serializeFiles } from '@/lib/schemas';
@@ -69,7 +70,7 @@ export function CreateEmail({
   const { mutateAsync: sendEmail } = useMutation(trpc.mail.send.mutationOptions());
   const [isComposeOpen, setIsComposeOpen] = useQueryState('isComposeOpen');
   const { data: activeConnection } = useActiveConnection();
-
+  const { data: settings } = useSettings();
   // If there was an error loading the draft, set the failed state
   useEffect(() => {
     if (draftError) {
@@ -104,8 +105,9 @@ export function CreateEmail({
     // Use the selected from email or the first alias (or default user email)
     const fromEmail = aliases?.[0]?.email ?? userEmail;
 
-    const zeroSignature =
-      '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>';
+    const zeroSignature = settings?.settings.zeroSignature
+      ? '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>'
+      : '';
 
     await sendEmail({
       to: data.to.map((email) => ({ email, name: email.split('@')[0] || email })),

--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -70,7 +70,7 @@ export function CreateEmail({
   const { mutateAsync: sendEmail } = useMutation(trpc.mail.send.mutationOptions());
   const [isComposeOpen, setIsComposeOpen] = useQueryState('isComposeOpen');
   const { data: activeConnection } = useActiveConnection();
-  const { data: settings } = useSettings();
+  const { data: settings, isLoading: settingsLoading } = useSettings();
   // If there was an error loading the draft, set the failed state
   useEffect(() => {
     if (draftError) {
@@ -198,6 +198,7 @@ export function CreateEmail({
               }
               initialSubject={typedDraft?.subject || initialSubject}
               autofocus={true}
+              settingsLoading={settingsLoading}
             />
           )}
         </div>

--- a/apps/mail/components/create/email-composer.tsx
+++ b/apps/mail/components/create/email-composer.tsx
@@ -58,6 +58,7 @@ interface EmailComposerProps {
   onClose?: () => void;
   className?: string;
   autofocus?: boolean;
+  settingsLoading?: boolean;
 }
 
 const isValidEmail = (email: string): boolean => {
@@ -89,6 +90,7 @@ export function EmailComposer({
   onClose,
   className,
   autofocus = false,
+  settingsLoading = false,
 }: EmailComposerProps) {
   const [showCc, setShowCc] = useState(initialCc.length > 0);
   const [showBcc, setShowBcc] = useState(initialBcc.length > 0);
@@ -976,7 +978,7 @@ export function EmailComposer({
             <button
               className="flex h-7 cursor-pointer items-center justify-center gap-1.5 overflow-hidden rounded-md bg-black pl-1.5 pr-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white"
               onClick={handleSend}
-              disabled={isLoading}
+              disabled={isLoading || settingsLoading}
             >
               <div className="flex items-center justify-center gap-2.5 pl-0.5">
                 <div className="text-center text-sm leading-none text-white dark:text-black">

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -4,9 +4,9 @@ import { EmailComposer } from '../create/email-composer';
 import { useHotkeysContext } from 'react-hotkeys-hook';
 import { useTRPC } from '@/providers/query-provider';
 import { useMutation } from '@tanstack/react-query';
+import { useSettings } from '@/hooks/use-settings';
 import { constructReplyBody } from '@/lib/utils';
 import { useThread } from '@/hooks/use-threads';
-import { useSession } from '@/lib/auth-client';
 import { serializeFiles } from '@/lib/schemas';
 import { useDraft } from '@/hooks/use-drafts';
 import { useEffect, useState } from 'react';
@@ -23,7 +23,6 @@ interface ReplyComposeProps {
 export default function ReplyCompose({ messageId }: ReplyComposeProps) {
   const [threadId] = useQueryState('threadId');
   const { data: emailData, refetch } = useThread(threadId);
-  const { data: session } = useSession();
   const [mode, setMode] = useQueryState('mode');
   const { enableScope, disableScope } = useHotkeysContext();
   const { data: aliases, isLoading: isLoadingAliases } = useEmailAliases();
@@ -33,6 +32,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
   const trpc = useTRPC();
   const { mutateAsync: sendEmail } = useMutation(trpc.mail.send.mutationOptions());
   const { data: activeConnection } = useActiveConnection();
+  const { data: settings } = useSettings();
 
   // Find the specific message to reply to
   const replyToMessage =
@@ -132,8 +132,9 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
           }))
         : undefined;
 
-      const zeroSignature =
-        '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>';
+      const zeroSignature = settings?.settings.zeroSignature
+        ? '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>'
+        : '';
 
       const replyBody = constructReplyBody(
         data.message + zeroSignature,

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -132,8 +132,11 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
           }))
         : undefined;
 
+      const zeroSignature =
+        '<p style="color: #666; font-size: 12px;">Sent via <a href="https://0.email/" style="color: #0066cc; text-decoration: none;">Zero</a></p>';
+
       const replyBody = constructReplyBody(
-        data.message,
+        data.message + zeroSignature,
         new Date(replyToMessage.receivedOn || '').toLocaleString(),
         replyToMessage.sender,
         toRecipients,

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -32,7 +32,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
   const trpc = useTRPC();
   const { mutateAsync: sendEmail } = useMutation(trpc.mail.send.mutationOptions());
   const { data: activeConnection } = useActiveConnection();
-  const { data: settings } = useSettings();
+  const { data: settings, isLoading: settingsLoading } = useSettings();
 
   // Find the specific message to reply to
   const replyToMessage =
@@ -239,6 +239,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
           };
         })}
         autofocus={shouldFocus}
+        settingsLoading={settingsLoading}
       />
     </div>
   );

--- a/apps/mail/locales/en.json
+++ b/apps/mail/locales/en.json
@@ -378,7 +378,9 @@
         "customPrompt": "Custom AI Prompt",
         "customPromptPlaceholder": "Enter your custom prompt for the AI...",
         "customPromptDescription": "Customize how the AI writes your email replies. This will be added to the base prompt.",
-        "noResultsFound": "No results found"
+        "noResultsFound": "No results found",
+        "zeroSignature": "Zero Signature",
+        "zeroSignatureDescription": "Add a Zero signature to your emails."
       },
       "connections": {
         "title": "Email Connections",

--- a/apps/server/src/lib/schemas.ts
+++ b/apps/server/src/lib/schemas.ts
@@ -43,6 +43,7 @@ export const defaultUserSettings = {
   trustedSenders: [],
   isOnboarded: false,
   colorTheme: 'system',
+  zeroSignature: true,
 } satisfies UserSettings;
 
 export const userSettingsSchema = z.object({
@@ -54,6 +55,7 @@ export const userSettingsSchema = z.object({
   isOnboarded: z.boolean().optional(),
   trustedSenders: z.string().array().optional(),
   colorTheme: z.enum(['light', 'dark', 'system']).default('system'),
+  zeroSignature: z.boolean().default(true),
 });
 
 export type UserSettings = z.infer<typeof userSettingsSchema>;


### PR DESCRIPTION
### TL;DR

Added a Zero email signature option that users can toggle in settings.

### What changed?

- Added a new `zeroSignature` boolean field to user settings with a default value of `true`
- Added a toggle switch in the settings page to control this feature
- Implemented the signature insertion logic in both the email composer and reply composer
- Added appropriate translations for the new setting

### How to test?

1. Go to Settings > General
2. Find the new "Zero Signature" toggle
3. Enable/disable the setting and save
4. Compose a new email or reply to an existing one
5. Verify that the signature "Sent via Zero" appears at the bottom of the email when enabled
6. Verify that no signature is added when disabled

### Why make this change?

This change allows users to control whether emails sent through the platform include a "Sent via Zero" signature. This provides brand visibility for the Zero email platform while giving users the flexibility to opt out if they prefer not to display this information in their communications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Zero Signature" toggle in user settings, allowing users to automatically append a "Sent via Zero" signature to their emails.
	- The signature is included in both new emails and replies when enabled.
- **Localization**
	- Added English text for the new "Zero Signature" setting and its description in the settings page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->