### PR TITLE
fixes shortcut key display

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -554,7 +554,7 @@ export function MailLayout() {
                       : 'Search...'}
                   </span>
 
-                  <span className="absolute right-[0.18rem] flex gap-1">
+                  <span className="absolute right-[0.1rem] flex gap-1">
                     {/* {activeFilters.length > 0 && (
                       <Badge variant="secondary" className="ml-2 h-5 rounded px-1">
                         {activeFilters.length}
@@ -573,8 +573,16 @@ export function MailLayout() {
                         Clear
                       </Button>
                     )}
-                    <kbd className="bg-muted text-md pointer-events-none hidden h-7 select-none items-center gap-0.5 rounded-md border-none px-2 font-medium opacity-100 sm:flex dark:bg-[#262626] dark:text-[#929292]">
-                      <span className="text-lg">{isMac ? '⌘' : 'Ctrl'}</span> K
+                    <kbd className="bg-muted text-md pointer-events-none hidden h-7 select-none flex-row items-center gap-1 rounded-md border-none px-2 font-medium !leading-[0] opacity-100 sm:flex dark:bg-[#262626] dark:text-[#929292]">
+                      <span
+                        className={cn(
+                          'h-min !leading-[0.2]',
+                          isMac ? 'mt-[1px] text-lg' : 'text-sm',
+                        )}
+                      >
+                        {isMac ? '⌘' : 'Ctrl'}{' '}
+                      </span>
+                      <span className="h-min text-sm !leading-[0.2]"> K</span>
                     </kbd>
                   </span>
                 </Button>


### PR DESCRIPTION
# Improved Search Keyboard Shortcut UI in Mail Component

## Description

Enhanced the visual appearance and alignment of the keyboard shortcut indicator in the mail search component. The changes include:

1. Adjusted the right positioning of the shortcut container from `0.18rem` to `0.1rem`
2. Improved the keyboard shortcut display by:
   - Adding proper flex-row layout and gap spacing
   - Setting appropriate leading values for better vertical alignment
   - Adding conditional styling for Mac vs Windows keyboard shortcuts
   - Separating the command key and 'K' into different spans for better control

These changes improve the visual consistency and readability of the keyboard shortcut indicator.

## Type of Change

- [x] 🎨 UI/UX improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual alignment and spacing of the keyboard shortcut hint in the mail filter controls for a more polished appearance across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->