### PR TITLE
optimistic thread state for thread context menu

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -124,19 +124,35 @@ const Thread = memo(
     const optimisticLabels = useMemo(() => {
       if (!getThreadData?.labels) return [];
 
-      const labels = [...getThreadData.labels];
+      let labels = [...getThreadData.labels];
       const hasStarredLabel = labels.some((label) => label.name === 'STARRED');
 
       if (optimisticState.optimisticStarred !== null) {
         if (optimisticState.optimisticStarred && !hasStarredLabel) {
           labels.push({ id: 'starred-optimistic', name: 'STARRED' });
         } else if (!optimisticState.optimisticStarred && hasStarredLabel) {
-          return labels.filter((label) => label.name !== 'STARRED');
+          labels = labels.filter((label) => label.name !== 'STARRED');
         }
       }
 
+      if (optimisticState.optimisticLabels) {
+        labels = labels.filter(
+          (label) => !optimisticState.optimisticLabels.removedLabelIds.includes(label.id),
+        );
+
+        optimisticState.optimisticLabels.addedLabelIds.forEach((labelId) => {
+          if (!labels.some((label) => label.id === labelId)) {
+            labels.push({ id: labelId, name: labelId });
+          }
+        });
+      }
+
       return labels;
-    }, [getThreadData?.labels, optimisticState.optimisticStarred]);
+    }, [
+      getThreadData?.labels,
+      optimisticState.optimisticStarred,
+      optimisticState.optimisticLabels,
+    ]);
 
     const { optimisticToggleStar, optimisticToggleImportant, optimisticMoveThreadsTo } =
       useOptimisticActions();
@@ -216,7 +232,7 @@ const Thread = memo(
     }, [latestMessage?.body, latestMessage?.sender?.email, settingsData?.settings, queryClient]);
 
     const { labels: threadLabels } = useThreadLabels(
-      getThreadData?.labels ? getThreadData.labels.map((l) => l.id) : [],
+      optimisticLabels ? optimisticLabels.map((l) => l.id) : [],
     );
 
     const mainSearchTerm = useMemo(() => {

--- a/apps/mail/components/mail/optimistic-thread-state.tsx
+++ b/apps/mail/components/mail/optimistic-thread-state.tsx
@@ -31,6 +31,10 @@ export function useOptimisticThreadState(threadId: string) {
       optimisticRead: null as boolean | null,
       optimisticDestination: null as string | null,
       optimisticImportant: null as boolean | null,
+      optimisticLabels: {
+        addedLabelIds: [] as string[],
+        removedLabelIds: [] as string[],
+      },
     };
 
     if (!isAffectedByOptimisticAction || !optimisticActions || optimisticActions.length === 0) {
@@ -57,6 +61,11 @@ export function useOptimisticThreadState(threadId: string) {
 
         case 'LABEL':
           states.isAddingLabel = action.add;
+          if (action.add) {
+            states.optimisticLabels.addedLabelIds.push(...action.labelIds);
+          } else {
+            states.optimisticLabels.removedLabelIds.push(...action.labelIds);
+          }
           break;
 
         case 'IMPORTANT':


### PR DESCRIPTION
# Implement Optimistic UI for Label Management in Email Threads

This PR adds optimistic UI updates for label management in email threads context menu.

## Type of Change

- ✨ New feature (non-breaking change which adds functionality)

## Areas Affected

- [x] User Interface/Experience
- [x] Data Storage/Management

## Testing Done

- [x] Manual testing performed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for bulk label toggling on multiple mail threads.
  - Labels now update instantly in the UI with optimistic updates, reflecting changes before server confirmation.

- **Improvements**
  - Checkbox states for labels now accurately reflect pending changes for a smoother user experience.
  - Enhanced feedback with toast messages indicating label changes, including support for multiple threads.

- **Style**
  - Minor formatting improvements in context menu components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->