### PR TITLE
fix: Fixed border and outline colors for the pricing dialog box in lightmode

### DIFF
--- a/apps/mail/components/ui/pricing-dialog.tsx
+++ b/apps/mail/components/ui/pricing-dialog.tsx
@@ -51,7 +51,7 @@ export function PricingDialog() {
       >
         <DialogTitle className="text-center text-2xl"></DialogTitle>
 
-        <div className="relative inline-flex h-[535px] w-96 flex-col items-center justify-center overflow-hidden rounded-2xl border border-[#2D2D2D] bg-zinc-900/50 p-5 outline outline-2 outline-offset-[3.5px] outline-[#2D2D2D]">
+        <div className="relative inline-flex h-[535px] w-96 flex-col items-center justify-center overflow-hidden rounded-2xl border border-gray-400 bg-zinc-900/50 p-5 outline outline-2 outline-offset-[4px] outline-gray-400 dark:border-[#2D2D2D] dark:outline-[#2D2D2D]">
           <div className="absolute inset-0 z-0 h-full w-full overflow-hidden">
             <img
               src="/pricing-gradient.png"
@@ -175,7 +175,7 @@ export function PricingDialog() {
             </div>
           </div>
           <button
-            className="z-50 inline-flex h-24 cursor-pointer items-center justify-center gap-2.5 self-stretch overflow-hidden rounded-lg bg-white p-3 outline outline-1 outline-offset-[-1px] disabled:cursor-not-allowed disabled:opacity-50"
+            className="z-50 inline-flex h-24 cursor-pointer items-center justify-center gap-2.5 self-stretch overflow-hidden rounded-lg bg-white p-3 outline outline-1 outline-offset-[-1px] outline-gray-400 disabled:cursor-not-allowed disabled:opacity-50 dark:outline-[#2D2D2D]"
             onClick={handleUpgrade}
             disabled={isLoading}
           >


### PR DESCRIPTION
before : 
![image](https://github.com/user-attachments/assets/ca449f51-6773-4df6-89ab-969e5104a8df)

after :
![image](https://github.com/user-attachments/assets/6064dbd9-1061-4d2c-a943-2e7dfe0dd050)
