### PR TITLE
feat: show sender details with copy email option in mail sender popover

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -907,6 +907,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
     }
   }, [isCollapsed, preventCollapse, openDetailsPopover]);
 
+    // Handle email copy of senders
+  const handleCopySenderEmail = useCallback(async (personEmail: string) => {
+      await navigator.clipboard.writeText(personEmail|| '');
+  }, []);
+
   // email printing
   const printMail = () => {
     try {
@@ -1306,13 +1311,32 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
             </div>
           </div>
         </PopoverTrigger>
-        <PopoverContent className="text-sm">
-          <p>Email: {person.email}</p>
-          <p>Name: {person.name || 'Unknown'}</p>
+        <PopoverContent className="text-sm min-w-fit">
+          <div className='flex items-center gap-2'>
+            <Avatar className="h-12 w-12">
+              <AvatarImage src={getEmailLogo(person.email)} className="rounded-full" />
+              <AvatarFallback className="bg-offsetLight rounded-full text-sm font-bold dark:bg-[#373737]">
+                {getFirstLetterCharacter(person.name || person.email)}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <p className='font-medium'>{person.name || 'Unknown'}</p>
+              <div className="flex gap-2 items-center group">
+                <p>{person.email || 'No email'}</p>
+                <span className="opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                  <CopyIcon
+                  size={14}
+                  className="cursor-pointer"
+                  onClick={() => handleCopySenderEmail(person.email)}
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
         </PopoverContent>
       </Popover>
     ),
-    [],
+    []
   );
 
   const people = useMemo(() => {


### PR DESCRIPTION
## Description

- Display avatar in the popover
- Add "copy to clipboard" functionality for sender email


---

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [ ] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

There should be a send email option directly from the popover . what do you think @MrgSub 

## Screenshots/Recordings

Before:
![Screenshot from 2025-06-17 17-09-39](https://github.com/user-attachments/assets/23bba4bb-627c-4cb5-b3d6-cd983fb1cd7d)

After:
[Screencast from 2025-06-17 17-38-06.webm](https://github.com/user-attachments/assets/d8db77c9-b223-49ce-9cc8-f38ef26573dd)

---





_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
