### PR TITLE
fixed clear button alingment issue in inbox search tab

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -549,7 +549,7 @@ export function MailLayout() {
                       : 'Search...'}
                   </span>
 
-                  <span className="absolute right-[0.1rem] flex gap-1">
+                  <span className="absolute right-[0.1rem] flex gap-1  items-center">
                     {/* {activeFilters.length > 0 && (
                       <Badge variant="secondary" className="ml-2 h-5 rounded px-1">
                         {activeFilters.length}


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-06-17 at 10 36 49 PM" src="https://github.com/user-attachments/assets/832c2d15-5edb-4d11-b6b2-95880c14ecc6" />
<img width="1440" alt="Screenshot 2025-06-17 at 10 38 35 PM" src="https://github.com/user-attachments/assets/77c5f847-2c28-4f69-a603-e9a3baa2d754" />

The search tab on the inbox page had an alignment issue for the clear button which is fixed using the align items:center property for the container 