### PR TITLE
fix default category

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -673,7 +673,7 @@ export const MailList = memo(
 
       const currentCategory = category
         ? allCategories.find((cat) => cat.id === category)
-        : allCategories.find((cat) => cat.id === 'Important');
+        : allCategories.find((cat) => cat.id === 'All Mail');
 
       if (currentCategory && searchValue.value === '') {
         setSearchValue({


### PR DESCRIPTION
## Description

Changed the default mail category from 'Important' to 'All Mail' when no category is explicitly selected. This ensures that users see all their mail by default rather than only important messages.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience
## Testing Done

- [x] Manual testing performed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the default mail category to "All Mail" when no category is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->