### PR TITLE
connect the draft to the thread

### DIFF
--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -229,6 +229,21 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
     };
   }, [mode, enableScope, disableScope]);
 
+  const ensureEmailArray = (emails: string | string[] | undefined | null): string[] => {
+    if (!emails) return [];
+    if (Array.isArray(emails)) {
+      return emails.map((email) => email.trim().replace(/[<>]/g, ''));
+    }
+    if (typeof emails === 'string') {
+      return emails
+        .split(',')
+        .map((email) => email.trim())
+        .filter((email) => email.length > 0)
+        .map((email) => email.replace(/[<>]/g, ''));
+    }
+    return [];
+  };
+
   if (!mode || !emailData) return null;
 
   return (
@@ -243,7 +258,9 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
           await setActiveReplyId(null);
         }}
         initialMessage={draft?.content ?? latestDraft?.decodedBody}
-        initialTo={draft?.to}
+        initialTo={ensureEmailArray(draft?.to)}
+        initialCc={ensureEmailArray(draft?.cc)}
+        initialBcc={ensureEmailArray(draft?.bcc)}
         initialSubject={draft?.subject}
         autofocus={false}
         settingsLoading={settingsLoading}

--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -1104,7 +1104,10 @@ export class GoogleMailManager implements MailManager {
       }
     }
 
-    // TODO: Hook up CC and BCC from the draft so it can populate the composer on open.
+    const cc =
+      draft.message.payload?.headers?.find((h) => h.name === 'Cc')?.value?.split(',') || [];
+    const bcc =
+      draft.message.payload?.headers?.find((h) => h.name === 'Bcc')?.value?.split(',') || [];
 
     return {
       id: draft.id || '',
@@ -1112,6 +1115,8 @@ export class GoogleMailManager implements MailManager {
       subject: subject ? he.decode(subject).trim() : '',
       content,
       rawMessage: draft.message,
+      cc,
+      bcc,
     };
   }
   private async withErrorHandler<T>(

--- a/apps/server/src/lib/driver/types.ts
+++ b/apps/server/src/lib/driver/types.ts
@@ -16,6 +16,8 @@ export interface ParsedDraft<T = unknown> {
   subject?: string;
   content?: string;
   rawMessage?: T;
+  cc?: string[];
+  bcc?: string[];
 }
 
 export interface IConfig {

--- a/apps/server/src/lib/schemas.ts
+++ b/apps/server/src/lib/schemas.ts
@@ -31,6 +31,7 @@ export const createDraftData = z.object({
   attachments: z.array(serializedFileSchema).transform(deserializeFiles).optional(),
   id: z.string().nullable(),
   threadId: z.string().nullable(),
+  fromEmail: z.string().nullable(),
 });
 
 export type CreateDraftData = z.infer<typeof createDraftData>;


### PR DESCRIPTION
# Add draft indicator and improve draft handling in mail threads

## Description

This PR adds visual indicators for drafts in mail threads and improves draft handling throughout the mail application:

1. Added a pencil icon indicator that appears next to threads containing drafts
2. Improved the display of latest messages by filtering out drafts when showing thread previews
3. Fixed draft handling in reply composer by properly parsing email addresses from drafts
4. Added support for CC and BCC fields when reopening drafts
5. Properly reset draft and reply state when navigating between threads
6. Enhanced the Google Mail Manager to include CC and BCC information from drafts

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Draft status is now visually indicated in mail threads with a draft icon.
  - Draft emails now support CC and BCC recipient fields, which are populated when composing or editing drafts.
  - The draft data structure now includes an optional sender email address field.

- **Bug Fixes**
  - Email recipient fields (To, CC, BCC) are consistently formatted and cleaned when initializing the email composer.

- **Improvements**
  - Navigating between threads or moving emails clears any draft or reply state to prevent unintended carryover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->