### PR TITLE
feat: add ability to change icons for email categories

### DIFF
--- a/apps/mail/app/(routes)/settings/categories/page.tsx
+++ b/apps/mail/app/(routes)/settings/categories/page.tsx
@@ -10,7 +10,15 @@ import { useTRPC } from '@/providers/query-provider';
 import { toast } from 'sonner';
 import type { CategorySetting } from '@/hooks/use-categories';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import * as Icons from '@/components/icons/icons';
 import { Sparkles } from '@/components/icons/icons';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
 import { Loader } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
@@ -47,7 +55,7 @@ export default function CategoriesSettingsPage() {
     setCategories(merged.sort((a, b) => a.order - b.order));
   }, [data, defaultMailCategories]);
 
-  const handleFieldChange = (id: string, field: keyof CategorySetting, value: any) => {
+  const handleFieldChange = (id: string, field: keyof CategorySetting, value: string | number | boolean) => {
     setCategories((prev) =>
       prev.map((cat) => (cat.id === id ? { ...cat, [field]: value } : cat)),
     );
@@ -70,7 +78,7 @@ export default function CategoriesSettingsPage() {
 
     try {
       await saveUserSettings({ categories: sortedCategories });
-      queryClient.setQueryData(trpc.settings.get.queryKey(), (updater: any) => {
+      queryClient.setQueryData(trpc.settings.get.queryKey(), (updater) => {
         if (!updater) return;
         return {
           settings: { ...updater.settings, categories: sortedCategories },
@@ -134,7 +142,7 @@ export default function CategoriesSettingsPage() {
               </div>
 
               <div className="grid grid-cols-12 gap-4 items-start">
-                <div className="col-span-12 sm:col-span-5">
+                <div className="col-span-12 sm:col-span-4">
                   <Label className="text-xs mb-1.5 block">Display Name</Label>
                   <Input
                     className="h-8 text-sm"
@@ -143,7 +151,43 @@ export default function CategoriesSettingsPage() {
                   />
                 </div>
                 
-                <div className="col-span-12 sm:col-span-5">
+                <div className="col-span-12 sm:col-span-2">
+                  <Label className="text-xs mb-1.5 block">Icon</Label>
+                  <Select
+                    value={cat.icon ?? ''}
+                    onValueChange={(val) => handleFieldChange(cat.id, 'icon', val)}
+                  >
+                    <SelectTrigger className="h-8 text-sm">
+                      <SelectValue placeholder="Select icon">
+                        {cat.icon && (
+                          <div className="flex items-center gap-2">
+                            {(() => {
+                              const IconComp = Icons[cat.icon as keyof typeof Icons];
+                              return IconComp ? <IconComp className="size-4 fill-muted-foreground" /> : null;
+                            })()}
+                            <span className="truncate">{cat.icon}</span>
+                          </div>
+                        )}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {Object.keys(Icons).map((iconName) => {
+                        const IconComp = Icons[iconName as keyof typeof Icons];
+                        if (typeof IconComp !== 'function') return null;
+                        return (
+                          <SelectItem value={iconName} key={iconName}>
+                            <div className="flex items-center gap-2">
+                              <IconComp className="size-4 fill-muted-foreground" />
+                              <span>{iconName}</span>
+                            </div>
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                </div>
+                
+                <div className="col-span-12 sm:col-span-4">
                   <Label className="text-xs mb-1.5 block">Search Query</Label>
                   <div className="relative">
                     <Input

--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -64,6 +64,7 @@ import { useQueryState } from 'nuqs';
 import { useAtom } from 'jotai';
 import { toast } from 'sonner';
 import { useCategorySettings, useDefaultCategoryId } from '@/hooks/use-categories';
+import * as CustomIcons from '@/components/icons/icons';
 
 interface ITag {
   id: string;
@@ -836,6 +837,20 @@ export const Categories = () => {
 
     // Helper to decide fill colour depending on selection
     const isSelected = activeCategory === cat.id;
+    if (cat.icon && cat.icon in CustomIcons) {
+      const DynamicIcon = CustomIcons[cat.icon as keyof typeof CustomIcons];
+      return {
+        ...base,
+        icon: (
+          <DynamicIcon
+            className={cn(
+              'fill-muted-foreground dark:fill-white h-4 w-4',
+              isSelected && 'fill-white',
+            )}
+          />
+        ),
+      };
+    }
 
     switch (cat.id) {
       case 'Important':

--- a/apps/mail/hooks/use-categories.ts
+++ b/apps/mail/hooks/use-categories.ts
@@ -8,7 +8,8 @@ export interface CategorySetting {
   name: string;
   searchValue: string;
   order: number;
-  isDefault?: boolean;
+  icon?: string;
+  isDefault: boolean;
 }
 
 export function useCategorySettings(): CategorySetting[] {

--- a/apps/server/src/lib/schemas.ts
+++ b/apps/server/src/lib/schemas.ts
@@ -39,6 +39,7 @@ export const mailCategorySchema = z.object({
   name: z.string(),
   searchValue: z.string(),
   order: z.number().int(),
+  icon: z.string().optional(),
   isDefault: z.boolean().optional().default(false),
 });
 
@@ -50,6 +51,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'Important',
     searchValue: 'is:important NOT is:sent NOT is:draft',
     order: 0,
+    icon: 'Lightning',
     isDefault: false,
   },
   {
@@ -57,6 +59,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'All Mail',
     searchValue: 'NOT is:draft (is:inbox OR (is:sent AND to:me))',
     order: 1,
+    icon: 'Mail',
     isDefault: true,
   },
   {
@@ -64,6 +67,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'Personal',
     searchValue: 'is:personal NOT is:sent NOT is:draft',
     order: 2,
+    icon: 'User',
     isDefault: false,
   },
   {
@@ -71,6 +75,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'Promotions',
     searchValue: 'is:promotions NOT is:sent NOT is:draft',
     order: 3,
+    icon: 'Tag',
     isDefault: false,
   },
   {
@@ -78,6 +83,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'Updates',
     searchValue: 'is:updates NOT is:sent NOT is:draft',
     order: 4,
+    icon: 'Bell',
     isDefault: false,
   },
   {
@@ -85,6 +91,7 @@ export const defaultMailCategories: MailCategory[] = [
     name: 'Unread',
     searchValue: 'is:unread NOT is:sent NOT is:draft',
     order: 5,
+    icon: 'ScanEye',
     isDefault: false,
   },
 ];


### PR DESCRIPTION
implements a dropdown for selecting custom icons for categories through `settings/categories`

https://github.com/user-attachments/assets/f18e610e-db3c-438b-ae99-911d1ed4f2f6

