### PR TITLE
fix: fixed user navbar ui Implements #1444

### DIFF
--- a/apps/mail/components/ui/nav-user.tsx
+++ b/apps/mail/components/ui/nav-user.tsx
@@ -576,29 +576,28 @@ export function NavUser() {
           </div>
         )}
       </div>
-
+      
       {state !== 'collapsed' && (
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center justify-between gap-2 mt-2">
           <div className="mt-[2px] flex flex-col items-start gap-1 space-y-1">
             <div className="flex items-center gap-1 text-[13px] leading-none text-black dark:text-white">
-              <p className={cn('truncate text-[13px]', isPro ? 'max-w-[14.5ch]' : 'max-w-[8.5ch]')}>
+              <p className={cn('truncate text-[13px] max-w-[14.5ch]')}>
                 {activeAccount?.name || session.user.name || 'User'}
               </p>
               {isPro ? (
                 <BadgeCheck className="h-4 w-4 text-white dark:text-[#141414]" fill="#1D9BF0" />
-              ) : (
-                <button
+              ) : null}
+            </div>
+            <div className="h-5 max-w-[200px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]">
+              {activeAccount?.email || session.user.email}
+            </div>
+            <button
                   onClick={() => setPricingDialog('true')}
                   className="flex h-5 items-center gap-1 rounded-full border px-1 pr-1.5 hover:bg-transparent"
                 >
                   <BadgeCheck className="h-4 w-4 text-white dark:text-[#141414]" fill="#1D9BF0" />
                   <span className="text-muted-foreground text-[10px] uppercase">Get verified</span>
                 </button>
-              )}
-            </div>
-            <div className="h-5 max-w-[200px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]">
-              {activeAccount?.email || session.user.email}
-            </div>
           </div>
 
           <div className="ml-2">{/* Gauge component removed */}</div>


### PR DESCRIPTION
I’ve updated the layout by moving the "Get Verified" button below the username instead of placing it beside it. This makes the top section of the user navbar look cleaner and prevents overflow issues when zooming in or out.
![image](https://github.com/user-attachments/assets/c08a92ce-0b3e-4d85-91cb-7405a6ce910c)
