### PR TITLE
feat: Alert user when attachment keywords are present but no file is attached

### DIFF
--- a/apps/mail/components/create/email-composer.tsx
+++ b/apps/mail/components/create/email-composer.tsx
@@ -131,6 +131,7 @@ export function EmailComposer({
   const bccWrapperRef = useRef<HTMLDivElement>(null);
   const { data: activeConnection } = useActiveConnection();
   const [showLeaveConfirmation, setShowLeaveConfirmation] = useState(false);
+  const [showAttachmentWarning, setShowAttachmentWarning] = useState(false);
 
   // Add this function to handle clicks outside the input fields
   useEffect(() => {
@@ -153,6 +154,14 @@ export function EmailComposer({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, []);
+
+  const attachmentKeywords = [
+    'attachment',
+    'attached',
+    'attaching',
+    'see the file',
+    'see the files',
+  ];
 
   const trpc = useTRPC();
   const { mutateAsync: aiCompose } = useMutation(trpc.ai.compose.mutationOptions());
@@ -355,7 +364,7 @@ export function EmailComposer({
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [editor, draftId]);
 
-  const handleSend = async () => {
+  const proceedWithSend = async () => {
     try {
       if (isLoading || isSavingDraft) return;
 
@@ -389,6 +398,19 @@ export function EmailComposer({
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleSend = async () => {
+    const values = getValues();
+    const messageText = editor.getText().toLowerCase();
+    const hasAttachmentKeywords = attachmentKeywords.some((keyword) => messageText.includes(keyword));
+
+    if (hasAttachmentKeywords && (!values.attachments || values.attachments.length === 0)) {
+      setShowAttachmentWarning(true);
+      return;
+    }
+
+    await proceedWithSend();
   };
 
   const threadContent: ThreadContent = useMemo(() => {
@@ -1416,6 +1438,36 @@ export function EmailComposer({
             </Button>
             <Button variant="destructive" onClick={confirmLeave}>
               Leave
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showAttachmentWarning} onOpenChange={setShowAttachmentWarning}>
+        <DialogContent showOverlay className="z-[99999] sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Attachment Warning</DialogTitle>
+            <DialogDescription>
+              Looks like you mentioned an attachment in your message, but there are no files attached.
+              Are you sure you want to send this email?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowAttachmentWarning(false);
+              }}
+            >
+              Recheck
+            </Button>
+            <Button
+              onClick={() => {
+                setShowAttachmentWarning(false);
+                void proceedWithSend();
+              }}
+            >
+              Send Anyway
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Description

Alerts the user if the email contains words like "attached" but no file is actually attached.

---

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

Before:

https://github.com/user-attachments/assets/87ba0672-7de7-4b53-8d8e-17ff54199b70



After:

https://github.com/user-attachments/assets/bba8eac7-2a1b-4cbf-9589-58ba90364417



---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
