### PR TITLE
on clicking download all attachement its makes the email ui collaspe …

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -1635,8 +1635,8 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                 <Printer className="fill-iconLight dark:fill-iconDark mr-2 h-4 w-4" />
                                 {t('common.mailDisplay.print')}
                               </DropdownMenuItem>
-                              <DropdownMenuItem
-                                disabled={!emailData.attachments?.length}
+                              {(emailData.attachments?.length ?? 0) > 0 && (
+                                <DropdownMenuItem
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   e.preventDefault();
@@ -1649,6 +1649,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                 <HardDriveDownload className="fill-iconLight dark:text-iconDark dark:fill-iconLight mr-2 h-4 w-4" />
                                 Download All Attachments
                               </DropdownMenuItem>
+                              )}
                             </DropdownMenuContent>
                           </DropdownMenu>
                         </div>


### PR DESCRIPTION
…sloving issue-#1539

## Description

This pull request fixes the issue where the email UI collapses when the "Download All Attachments" button is clicked, even when there are no attachments available. The download button is now conditionally rendered only if `attachments.length > 0`, preventing the UI glitch and unnecessary interaction.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## Areas Affected

- [x] User Interface/Experience

---

## Testing Done

- [x] Manual testing performed
- [x] Mobile responsiveness verified (UI changes)

---

## Security Considerations

- [x] No sensitive data is exposed

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] My changes generate no new warnings
- [x] All tests pass locally

---

## Additional Notes

Let me know if further changes are needed. Open to feedback.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
