### PR TITLE
Feat: Note Tooltip On Hover + Note Text Overflow fixes

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -552,7 +552,7 @@ const Thread = memo(
                               <StickyNote className="h-3 w-3 fill-amber-500 stroke-amber-500 dark:fill-amber-400 dark:stroke-amber-400" />
                             </span>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom" className="p-1 text-xs max-w-72 border-yellow-300 border-solid">
+                          <TooltipContent side="bottom" className="p-1 text-xs md:max-w-52 max-w-60 border-yellow-300 border-solid">
                             <p className="truncate">{lastNoteContent}</p>
                           </TooltipContent>
                         </Tooltip>

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -14,7 +14,6 @@ import {
   Trash,
   PencilCompose,
 } from '../icons/icons';
-import { StickyNote } from 'lucide-react';
 import {
   memo,
   useCallback,
@@ -43,6 +42,7 @@ import { useTRPC } from '@/providers/query-provider';
 import { useThreadLabels } from '@/hooks/use-labels';
 import { template } from '@/lib/email-utils.client';
 import { useSettings } from '@/hooks/use-settings';
+import { useThreadNotes } from '@/hooks/use-notes';
 import { useKeyState } from '@/hooks/use-hot-key';
 import { VList, type VListHandle } from 'virtua';
 import { RenderLabels } from './render-labels';
@@ -51,13 +51,13 @@ import { useDraft } from '@/hooks/use-drafts';
 import { Check, Star } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { Skeleton } from '../ui/skeleton';
+import { StickyNote } from 'lucide-react';
 import { useParams } from 'react-router';
 import { useTheme } from 'next-themes';
 import { Button } from '../ui/button';
 import { useQueryState } from 'nuqs';
 import { Categories } from './mail';
 import { useAtom } from 'jotai';
-import { useThreadNotes } from '@/hooks/use-notes';
 
 const Thread = memo(
   function Thread({
@@ -105,6 +105,12 @@ const Thread = memo(
     const hasNotes = useMemo(() => {
       return (threadNotes?.notes && threadNotes.notes.length > 0) || false;
     }, [threadNotes?.notes]);
+
+    // Get the last note content
+
+    const lastNoteContent = useMemo(() => {
+    return ( hasNotes && threadNotes.notes[threadNotes.notes.length - 1]?.content) || '';
+    }, [hasNotes, threadNotes.notes]);
 
     const optimisticState = useOptimisticThreadState(idToUse ?? '');
 
@@ -540,9 +546,16 @@ const Thread = memo(
                         </Tooltip>
                       ) : null}
                       {hasNotes ? (
-                        <span className="inline-flex items-center">
-                          <StickyNote className="h-3 w-3 fill-amber-500 stroke-amber-500 dark:fill-amber-400 dark:stroke-amber-400" />
-                        </span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex items-center">
+                              <StickyNote className="h-3 w-3 fill-amber-500 stroke-amber-500 dark:fill-amber-400 dark:stroke-amber-400" />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="p-1 text-xs max-w-72 border-yellow-300 border-solid">
+                            <p className="truncate">{lastNoteContent}</p>
+                          </TooltipContent>
+                        </Tooltip>
                       ) : null}
                       <MailLabels labels={optimisticLabels} />
                     </div>
@@ -700,14 +713,14 @@ const Draft = memo(({ message }: { message: { id: string } }) => {
                     </span>
                   </span>
                 </div>
-                {draft.rawMessage?.internalDate && (  
-                <p 
-                  className={cn(
-                    'text-muted-foreground text-nowrap text-xs font-normal opacity-70 transition-opacity group-hover:opacity-100 dark:text-[#8C8C8C]',
-                  )}
-                >
-                  {formatDate(Number(draft.rawMessage?.internalDate))}
-                </p>
+                {draft.rawMessage?.internalDate && (
+                  <p
+                    className={cn(
+                      'text-muted-foreground text-nowrap text-xs font-normal opacity-70 transition-opacity group-hover:opacity-100 dark:text-[#8C8C8C]',
+                    )}
+                  >
+                    {formatDate(Number(draft.rawMessage?.internalDate))}
+                  </p>
                 )}
               </div>
               <div className="flex justify-between">

--- a/apps/mail/components/mail/note-panel.tsx
+++ b/apps/mail/components/mail/note-panel.tsx
@@ -132,7 +132,7 @@ function SortableNote({
 
       <div className="flex items-start gap-3 pl-1.5">
         <div className="min-w-0 flex-1">
-          <p className="whitespace-pre-wrap break-words text-sm text-black dark:text-white/90">
+          <p className="whitespace-pre-wrap break-words text-sm text-black dark:text-white/90 max-h-60 overflow-y-auto">
             {note.content}
           </p>
 
@@ -534,9 +534,9 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
             <span className="sr-only">{t('common.notes.title')}</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="bottom" className="bg-white dark:bg-[#313131]">
+        {!isOpen && <TooltipContent side="bottom" className="bg-white dark:bg-[#313131]">
           <p>{t('common.notes.noteCount', { count: notes.length })}</p>
-        </TooltipContent>
+        </TooltipContent>}
       </Tooltip>
 
       {isOpen && (
@@ -587,7 +587,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
               onDragEnd={handleDragEnd}
             >
               <ScrollArea className="flex-1 overflow-y-auto">
-                <div className="p-3">
+                <div className="p-3 max-w-[350px]">
                   {notes.length === 0 && !isAddingNewNote ? (
                     <div className="flex flex-col items-center justify-center py-8 text-center">
                       <StickyNote className="mb-2 h-12 w-12 text-[#8C8C8C] opacity-50" />


### PR DESCRIPTION
Added feature to view last added note without opening notes panel + bugs fixes

---------------------------------------------------------------------------------------------

BEFORE
-----------

1.  Text and Add notes button overflows if text is very long.

<img width="761" alt="image" src="https://github.com/user-attachments/assets/2e603a77-2014-433e-a2c8-a89fda339940" />

2. Tooltip occurs even when note-panel is open in bg
<img width="469" alt="image" src="https://github.com/user-attachments/assets/80d50eb6-f220-43ab-939b-a5c4344a8c1f" />



AFTER
-------------

1. View last note added on icon hover 
<img width="570" alt="image" src="https://github.com/user-attachments/assets/7d3039db-5c3d-4844-946a-da88ec0e0d77" />

For Large Texts
<img width="633" alt="image" src="https://github.com/user-attachments/assets/68799b87-3a53-499f-ac68-236e237863a1" />


2. Text overflow fixed and very long text will have scroll to prevent taking large space.
<img width="457" alt="image" src="https://github.com/user-attachments/assets/7a7c72a2-7e03-4d39-98ef-d460931690fb" />

3. Bg Tooltip fixed

