### PR TITLE
fix: Settings - labels new design

### DIFF
--- a/apps/mail/app/(routes)/settings/labels/page.tsx
+++ b/apps/mail/app/(routes)/settings/labels/page.tsx
@@ -105,74 +105,71 @@ export default function LabelsPage() {
         <div className="space-y-6">
           <Separator />
           <ScrollArea className="h-full pr-4">
-            <div className="space-y-4">
-              {isLoading && !error ? (
-                <div className="flex h-32 items-center justify-center">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-neutral-900 border-t-transparent dark:border-white dark:border-t-transparent" />
-                </div>
-              ) : error ? (
-                <p className="text-muted-foreground py-4 text-center text-sm">{error.message}</p>
-              ) : labels?.length === 0 ? (
-                <p className="text-muted-foreground py-4 text-center text-sm">
-                 {t('common.mail.noLabelsAvailable')}
-                </p>
-              ) : (
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-6">
-                  {labels?.map((label) => {
-                    return (
-                      <div
-                        key={label.id}
-                        className="hover:bg-muted/50 group relative flex items-center justify-between rounded-lg p-3 transition-colors"
-                      >
-                        <div className="flex items-center space-x-3">
-                          <Badge
-                            className="px-2 py-1"
-                            style={{
-                              backgroundColor: label.color?.backgroundColor,
-                              color: label.color?.textColor,
-                            }}
-                          >
-                            <span>{label.name}</span>
-                          </Badge>
-                        </div>
-                        <div className="dark:bg-panelDark absolute right-2 z-[25] flex items-center gap-1 rounded-xl border bg-white p-1 opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 [&_svg]:size-3.5"
-                                onClick={() => handleEdit(label)}
-                              >
-                                <Pencil className="text-[#898989]" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent className="dark:bg-panelDark mb-1 bg-white">
-                               {t('common.labels.editLabel')}
-                            </TooltipContent>
-                          </Tooltip>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 hover:bg-[#FDE4E9] dark:hover:bg-[#411D23] [&_svg]:size-3.5"
-                                onClick={() => handleDelete(label.id!)}
-                              >
-                                <Bin className="fill-[#F43F5E]" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent className="dark:bg-panelDark mb-1 bg-white">
-                              {t('common.labels.deleteLabel')}
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
+            {isLoading && !error ? (
+              <div className="flex h-32 items-center justify-center">
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-neutral-900 border-t-transparent dark:border-white dark:border-t-transparent" />
+              </div>
+            ) : error ? (
+              <p className="text-muted-foreground py-4 text-center text-sm">{error.message}</p>
+            ) : labels?.length === 0 ? (
+              <p className="text-muted-foreground py-4 text-center text-sm">
+               {t('common.mail.noLabelsAvailable')}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {labels?.map((label) => {
+                  return (
+                    <div
+                      key={label.id}
+                      className="group relative flex items-center justify-between rounded-lg border border-border/40 p-3 transition-colors hover:bg-muted/50"
+                    >
+                      <div className="flex items-center space-x-3">
+                        <Badge
+                          className="h-6 min-w-[24px] px-2"
+                          style={{
+                            backgroundColor: label.color?.backgroundColor,
+                            color: label.color?.textColor,
+                          }}
+                        />
+                        <span className="font-medium">{label.name}</span>
                       </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
+                      <div className="flex items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 opacity-0 group-hover:opacity-100"
+                              onClick={() => handleEdit(label)}
+                            >
+                              <Pencil className="h-4 w-4 text-iconDark dark:text-iconLight" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                             {t('common.labels.editLabel')}
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 opacity-0 group-hover:opacity-100 hover:bg-[#FDE4E9] hover:text-destructive dark:hover:bg-[#411D23]"
+                              onClick={() => handleDelete(label.id!)}
+                            >
+                              <Bin className="h-4 w-4 fill-destructive" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {t('common.labels.deleteLabel')}
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </ScrollArea>
         </div>
       </SettingsCard>

--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -19,9 +19,11 @@ import type { Label as LabelType } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
 import { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
 import { useForm } from 'react-hook-form';
-import { Command } from 'lucide-react';
+import { Command, Check } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 
 interface LabelDialogProps {
@@ -92,14 +94,14 @@ export function LabelDialog({
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-      <DialogContent showOverlay={true}>
+      <DialogContent showOverlay={true} className="max-w-md">
         <DialogHeader>
           <DialogTitle>{editingLabel ? t('common.labels.editLabel') : t('common.mail.createNewLabel')}</DialogTitle>
         </DialogHeader>
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(handleSubmit)}
-            className="mt-4 space-y-4"
+            className="mt-4 space-y-6"
             onKeyDown={(e) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                 e.preventDefault();
@@ -107,53 +109,87 @@ export function LabelDialog({
               }
             }}
           >
-            <div className="space-y-2">
+            <div className="space-y-4">
               <FormField
                 control={form.control}
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t('common.labels.labelName')}</FormLabel>
+                    <FormLabel className="text-sm font-medium">{t('common.labels.labelName')}</FormLabel>
                     <FormControl>
-                      <Input placeholder="Enter label name" {...field} autoFocus />
+                      <Input 
+                        placeholder={t('common.labels.enterLabelName')}
+                        {...field} 
+                        autoFocus
+                        className="h-10" 
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-              <div className="space-y-2">
-                <Label>{t('common.labels.color')}</Label>
-                <div className="w-full">
-                  <div className="flex flex-wrap gap-2">
-                    {LABEL_COLORS.map((color, index) => (
-                      <button
-                        key={index}
-                        type="button"
-                        className={`h-10 w-10 rounded-[4px] border-[0.5px] border-white/10 transition-all ${
-                          formColor?.backgroundColor.toString() === color.backgroundColor &&
-                          formColor.textColor.toString() === color.textColor
-                            ? 'scale-110 ring-2 ring-blue-500 ring-offset-1'
-                            : 'hover:scale-105'
-                        }`}
-                        style={{ backgroundColor: color.backgroundColor }}
-                        onClick={() =>
-                          form.setValue('color', {
-                            backgroundColor: color.backgroundColor,
-                            textColor: color.textColor,
-                          })
-                        }
-                      />
-                    ))}
-                  </div>
+
+              <div className="space-y-3">
+                <FormLabel className="text-sm font-medium">{t('common.labels.color')}</FormLabel>
+                
+                <div className="flex items-center gap-4 mb-2">
+                  <Badge
+                    className="h-6 min-w-[24px] px-2"
+                    style={{
+                      backgroundColor: formColor?.backgroundColor,
+                      color: formColor?.textColor,
+                    }}
+                  />
+                  <span className="text-sm">
+                    {form.watch('name') || t('common.labels.labelPreview')}
+                  </span>
+                </div>
+
+                <div className="grid grid-cols-4 sm:grid-cols-6 gap-3">
+                  {LABEL_COLORS.map((color, index) => (
+                    <button
+                      key={index}
+                      type="button"
+                      className={cn(
+                        "relative h-10 rounded-md transition-all hover:scale-105 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
+                        formColor?.backgroundColor === color.backgroundColor && 
+                        formColor?.textColor === color.textColor && 
+                        "ring-2 ring-primary"
+                      )}
+                      style={{ backgroundColor: color.backgroundColor }}
+                      onClick={() =>
+                        form.setValue('color', {
+                          backgroundColor: color.backgroundColor,
+                          textColor: color.textColor,
+                        })
+                      }
+                    >
+                      {formColor?.backgroundColor === color.backgroundColor && 
+                       formColor?.textColor === color.textColor && (
+                        <Check className="absolute inset-0 m-auto h-5 w-5" style={{ color: color.textColor }} />
+                      )}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>
-            <div className="flex justify-end gap-2">
-              <Button className="h-8" type="button" variant="outline" onClick={handleClose}>
+            
+            <div className="flex justify-end gap-2 pt-2">
+              <Button 
+                type="button" 
+                variant="outline" 
+                onClick={handleClose}
+                className="h-9"
+              >
                 {t('common.actions.cancel')}
               </Button>
-              <Button className="h-8 [&_svg]:size-4" type="submit">
-                {editingLabel ? t('common.actions.saveChanges') : t('common.labels.createLabel')}
+              <Button 
+                type="submit" 
+                className="h-9"
+              >
+                <span className="mr-1">
+                  {editingLabel ? t('common.actions.saveChanges') : t('common.labels.createLabel')}
+                </span>
                 <div className="flex h-5 items-center justify-center gap-1 rounded-sm bg-white/10 px-1 dark:bg-black/10">
                   <Command className="h-3 w-3 text-white dark:text-[#929292]" />
                   <CurvedArrow className="mt-1.5 h-3.5 w-3.5 fill-white dark:fill-[#929292]" />


### PR DESCRIPTION
## Description

In settings label section, the labels display is not properly done effecting the user experience. This PR solves the issue.

---

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

Before:
![image](https://github.com/user-attachments/assets/38187836-40e9-4fd5-adae-728bb9a22737)


After:
![image](https://github.com/user-attachments/assets/0be6a420-2268-424f-8b74-dbb75f793ce9)


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
