### PR TITLE
update posthog

### DIFF
--- a/apps/mail/package.json
+++ b/apps/mail/package.json
@@ -84,7 +84,7 @@
     "nuqs": "2.4.0",
     "partysocket": "^1.1.4",
     "pluralize": "^8.0.0",
-    "posthog-js": "1.236.6",
+    "posthog-js": "1.256.0",
     "prosemirror-model": "1.25.1",
     "prosemirror-state": "1.4.3",
     "prosemirror-view": "1.39.3",
@@ -117,6 +117,8 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.3.1",
+    "@inlang/cli": "^3.0.0",
+    "@inlang/paraglide-js": "2.1.0",
     "@tailwindcss/typography": "0.5.16",
     "@types/accept-language-parser": "^1.5.8",
     "@types/canvas-confetti": "1.9.0",
@@ -137,8 +139,6 @@
     "typescript": "catalog:",
     "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4",
-    "wrangler": "catalog:",
-    "@inlang/paraglide-js": "2.1.0",
-    "@inlang/cli": "^3.0.0"
+    "wrangler": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       posthog-js:
-        specifier: 1.236.6
-        version: 1.236.6
+        specifier: 1.256.0
+        version: 1.256.0
       prosemirror-model:
         specifier: 1.25.1
         version: 1.25.1
@@ -6246,8 +6246,8 @@ packages:
     resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
     engines: {node: '>=12'}
 
-  posthog-js@1.236.6:
-    resolution: {integrity: sha512-IX4fkn3HCK+ObdHr/AuWd+Ks7bgMpRpOQB93b5rDJAWkG4if4xFVUn5pgEjyCNeOO2GM1ECnp08q9tYNYEfwbA==}
+  posthog-js@1.256.0:
+    resolution: {integrity: sha512-LJSj4VcuLQGlsk4aQDOydx+oSj5+nlXHvHPDcAmzLucfoJEUi5CmluUU78V5+MwswoUHYZdGf5TPae3EXQk3FQ==}
     peerDependencies:
       '@rrweb/types': 2.0.0-alpha.17
       rrweb-snapshot: 2.0.0-alpha.17
@@ -13539,7 +13539,7 @@ snapshots:
 
   postgres@3.4.5: {}
 
-  posthog-js@1.236.6:
+  posthog-js@1.256.0:
     dependencies:
       core-js: 3.43.0
       fflate: 0.4.8


### PR DESCRIPTION
Updates the PostHog JS dependency from version 1.236.6 to 1.256.0 in the mail application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated "posthog-js" to the latest version.
  * Reorganized development dependencies for improved project maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->