### PR TITLE
use bimi records to get logos

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -34,15 +34,16 @@ import {
 import { cn, getEmailLogo, formatDate, formatTime, shouldShowSeparateTime } from '@/lib/utils';
 import { Dialog, DialogTitle, DialogHeader, DialogContent } from '../ui/dialog';
 import { memo, useEffect, useMemo, useState, useRef, useCallback } from 'react';
+import { BimiAvatar, getFirstLetterCharacter } from '../ui/bimi-avatar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import type { Sender, ParsedMessage, Attachment } from '@/types';
 import { useActiveConnection } from '@/hooks/use-connections';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useBrainState } from '../../hooks/use-summary';
 import { useTRPC } from '@/providers/query-provider';
 import { useThreadLabels } from '@/hooks/use-labels';
-import { useMutation } from '@tanstack/react-query';
 import { Markdown } from '@react-email/components';
 import { useSummary } from '@/hooks/use-summary';
 import { TextShimmer } from '../ui/text-shimmer';
@@ -381,13 +382,6 @@ const MailDisplayLabels = ({ labels }: { labels: string[] }) => {
       })}
     </div>
   );
-};
-
-// Helper function to get first letter character
-const getFirstLetterCharacter = (name?: string) => {
-  if (!name) return '';
-  const match = name.match(/[a-zA-Z]/);
-  return match ? match[0].toUpperCase() : '';
 };
 
 // Helper function to clean email display
@@ -1294,12 +1288,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
             key={person.email}
             className="dark:bg-panelDark inline-flex items-center justify-start gap-1.5 overflow-hidden rounded-full border bg-white p-1 pr-2"
           >
-            <Avatar className="h-5 w-5">
-              <AvatarImage src={getEmailLogo(person.email)} className="rounded-full" />
-              <AvatarFallback className="bg-offsetLight rounded-full text-xs font-bold dark:bg-[#373737]">
-                {getFirstLetterCharacter(person.name || person.email)}
-              </AvatarFallback>
-            </Avatar>
+            <BimiAvatar
+              email={person.email}
+              name={person.name || person.email}
+              className="h-5 w-5"
+            />
             <div className="text-panelDark justify-start text-sm font-medium leading-none dark:text-white">
               {person.name || person.email}
             </div>
@@ -1307,12 +1300,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
         </PopoverTrigger>
         <PopoverContent className="min-w-fit text-sm">
           <div className="flex items-center gap-2">
-            <Avatar className="h-12 w-12">
-              <AvatarImage src={getEmailLogo(person.email)} className="rounded-full" />
-              <AvatarFallback className="bg-offsetLight rounded-full text-sm font-bold dark:bg-[#373737]">
-                {getFirstLetterCharacter(person.name || person.email)}
-              </AvatarFallback>
-            </Avatar>
+            <BimiAvatar
+              email={person.email}
+              name={person.name || person.email}
+              className="h-12 w-12"
+            />
             <div>
               <p className="font-medium">{person.name || 'Unknown'}</p>
               <div className="group flex items-center gap-2">
@@ -1448,15 +1440,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
           >
             <div className="mt-3 flex w-full items-start justify-between gap-4 px-4">
               <div className="flex w-full justify-center gap-4">
-                <Avatar className="mt-3 h-8 w-8 rounded-full border dark:border-none">
-                  <AvatarImage
-                    className="rounded-full"
-                    src={getEmailLogo(emailData?.sender?.email)}
-                  />
-                  <AvatarFallback className="rounded-full bg-[#FFFFFF] font-bold text-[#9F9F9F] dark:bg-[#373737]">
-                    {getFirstLetterCharacter(emailData?.sender?.name)}
-                  </AvatarFallback>
-                </Avatar>
+                <BimiAvatar email={emailData?.sender?.email} name={emailData?.sender?.name} />
 
                 <div className="flex w-full items-center justify-between">
                   <div className="flex w-full items-center justify-start">

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -47,6 +47,7 @@ import { useSettings } from '@/hooks/use-settings';
 import { useThreadNotes } from '@/hooks/use-notes';
 import { useKeyState } from '@/hooks/use-hot-key';
 import { VList, type VListHandle } from 'virtua';
+import { BimiAvatar } from '../ui/bimi-avatar';
 import { RenderLabels } from './render-labels';
 import { Badge } from '@/components/ui/badge';
 import { useDraft } from '@/hooks/use-drafts';
@@ -362,55 +363,47 @@ const Thread = memo(
               className={`relative flex w-full items-center justify-between gap-4 px-4 ${displayUnread ? '' : 'opacity-60'}`}
             >
               <div>
-                <Avatar
-                  className={cn(
-                    'h-8 w-8 rounded-full',
-                    displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
-                  )}
-                >
-                  <div
+                {isMailBulkSelected ? (
+                  <Avatar
                     className={cn(
-                      'flex h-full w-full items-center justify-center rounded-full bg-[#006FFE] p-2 dark:bg-[#006FFE]',
-                      {
-                        hidden: !isMailBulkSelected,
-                      },
+                      'h-8 w-8 rounded-full',
+                      displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
                     )}
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      setMail((prev: Config) => ({
-                        ...prev,
-                        bulkSelected: prev.bulkSelected.filter((id: string) => id !== idToUse),
-                      }));
-                    }}
                   >
-                    <Check className="h-4 w-4 text-white" />
-                  </div>
-                  {isGroupThread ? (
+                    <div
+                      className="flex h-full w-full items-center justify-center rounded-full bg-[#006FFE] p-2 dark:bg-[#006FFE]"
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        setMail((prev: Config) => ({
+                          ...prev,
+                          bulkSelected: prev.bulkSelected.filter((id: string) => id !== idToUse),
+                        }));
+                      }}
+                    >
+                      <Check className="h-4 w-4 text-white" />
+                    </div>
+                  </Avatar>
+                ) : isGroupThread ? (
+                  <Avatar
+                    className={cn(
+                      'h-8 w-8 rounded-full',
+                      displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
+                    )}
+                  >
                     <div className="flex h-full w-full items-center justify-center rounded-full bg-[#FFFFFF] p-2 dark:bg-[#373737]">
                       <GroupPeople className="h-4 w-4" />
                     </div>
-                  ) : (
-                    <>
-                      <AvatarImage
-                        className="rounded-full bg-[#FFFFFF] dark:bg-[#373737]"
-                        src={getEmailLogo(latestMessage.sender.email)}
-                        alt={cleanName || latestMessage.sender.email}
-                        onError={(e) => {
-                          const target = e.target as HTMLImageElement;
-                          target.style.display = 'none';
-                        }}
-                      />
-                      <AvatarFallback
-                        className="rounded-full bg-[#FFFFFF] font-bold text-[#9F9F9F] dark:bg-[#373737]"
-                        delayMs={0}
-                      >
-                        {cleanName
-                          ? cleanName[0]?.toUpperCase()
-                          : latestMessage.sender.email[0]?.toUpperCase()}
-                      </AvatarFallback>
-                    </>
-                  )}
-                </Avatar>
+                  </Avatar>
+                ) : (
+                  <BimiAvatar
+                    email={latestMessage.sender.email}
+                    name={cleanName || latestMessage.sender.email}
+                    className={cn(
+                      'h-8 w-8 rounded-full',
+                      displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
+                    )}
+                  />
+                )}
                 {/* {displayUnread && !isMailSelected && !isFolderSent ? (
                   <>
                     <span className="absolute left-2 top-2 size-1.5 rounded bg-[#006FFE]" />

--- a/apps/mail/components/ui/bimi-avatar.tsx
+++ b/apps/mail/components/ui/bimi-avatar.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { useTRPC } from '@/providers/query-provider';
 import { useQuery } from '@tanstack/react-query';
 import { getEmailLogo } from '@/lib/utils';
+import DOMPurify from 'dompurify';
 
 export const getFirstLetterCharacter = (name?: string) => {
   if (!name) return '';
@@ -65,7 +66,7 @@ export const BimiAvatar = ({
       {bimiData?.logo?.svgContent && !isLoading ? (
         <div
           className="flex h-full w-full items-center justify-center overflow-hidden rounded-full bg-white dark:bg-[#373737]"
-          dangerouslySetInnerHTML={{ __html: bimiData.logo.svgContent }}
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bimiData.logo.svgContent) }}
         />
       ) : fallbackImageSrc && !useDefaultFallback ? (
         <AvatarImage

--- a/apps/mail/components/ui/bimi-avatar.tsx
+++ b/apps/mail/components/ui/bimi-avatar.tsx
@@ -1,0 +1,89 @@
+import { Avatar, AvatarFallback, AvatarImage } from './avatar';
+import { useState, useCallback, useMemo } from 'react';
+import { useTRPC } from '@/providers/query-provider';
+import { useQuery } from '@tanstack/react-query';
+import { getEmailLogo } from '@/lib/utils';
+
+export const getFirstLetterCharacter = (name?: string) => {
+  if (!name) return '';
+  const match = name.match(/[a-zA-Z]/);
+  return match ? match[0].toUpperCase() : '';
+};
+
+interface BimiAvatarProps {
+  email?: string;
+  name?: string;
+  className?: string;
+  fallbackClassName?: string;
+  onImageError?: (e: React.SyntheticEvent<HTMLImageElement>) => void;
+}
+
+export const BimiAvatar = ({
+  email,
+  name,
+  className = 'h-8 w-8 rounded-full border dark:border-none',
+  fallbackClassName = 'rounded-full bg-[#FFFFFF] font-bold text-[#9F9F9F] dark:bg-[#373737]',
+  onImageError,
+}: BimiAvatarProps) => {
+  const trpc = useTRPC();
+  const [useDefaultFallback, setUseDefaultFallback] = useState(false);
+
+  const { data: bimiData, isLoading } = useQuery({
+    ...trpc.bimi.getByEmail.queryOptions({ email: email || '' }),
+    enabled: !!email && !useDefaultFallback,
+    staleTime: 1000 * 60 * 60 * 24, // Cache for 24 hours
+    gcTime: 1000 * 60 * 60 * 24 * 7, // Keep in cache for 7 days
+  });
+
+  const fallbackImageSrc = useMemo(() => {
+    if (useDefaultFallback || !email) return '';
+    return getEmailLogo(email);
+  }, [email, useDefaultFallback]);
+
+  const handleFallbackImageError = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      setUseDefaultFallback(true);
+      if (onImageError) {
+        onImageError(e);
+      }
+    },
+    [onImageError],
+  );
+
+  const firstLetter = getFirstLetterCharacter(name || email);
+
+  if (!email) {
+    return (
+      <Avatar className={className}>
+        <AvatarFallback className={fallbackClassName}>{firstLetter}</AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  return (
+    <Avatar className={className}>
+      {bimiData?.logo?.svgContent && !isLoading ? (
+        <div
+          className="flex h-full w-full items-center justify-center overflow-hidden rounded-full bg-white dark:bg-[#373737]"
+          dangerouslySetInnerHTML={{ __html: bimiData.logo.svgContent }}
+        />
+      ) : fallbackImageSrc && !useDefaultFallback ? (
+        <AvatarImage
+          className="rounded-full bg-[#FFFFFF] dark:bg-[#373737]"
+          src={fallbackImageSrc}
+          alt={name || email}
+          onError={handleFallbackImageError}
+        />
+      ) : getEmailLogo(email) ? (
+        <AvatarImage
+          className="rounded-full bg-[#FFFFFF] dark:bg-[#373737]"
+          src={getEmailLogo(email)}
+          alt={name || email}
+          onError={handleFallbackImageError}
+        />
+      ) : (
+        <AvatarFallback className={fallbackClassName}>{firstLetter}</AvatarFallback>
+      )}
+    </Avatar>
+  );
+};

--- a/apps/server/src/trpc/index.ts
+++ b/apps/server/src/trpc/index.ts
@@ -1,6 +1,7 @@
 import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import { cookiePreferencesRouter } from './routes/cookies';
 import { connectionsRouter } from './routes/connections';
+import { categoriesRouter } from './routes/categories';
 import { shortcutRouter } from './routes/shortcut';
 import { settingsRouter } from './routes/settings';
 import { getContext } from 'hono/context-storage';
@@ -10,13 +11,14 @@ import { notesRouter } from './routes/notes';
 import { brainRouter } from './routes/brain';
 import { userRouter } from './routes/user';
 import { mailRouter } from './routes/mail';
+import { bimiRouter } from './routes/bimi';
 import type { HonoContext } from '../ctx';
 import { aiRouter } from './routes/ai';
 import { router } from './trpc';
-import { categoriesRouter } from './routes/categories';
 
 export const appRouter = router({
   ai: aiRouter,
+  bimi: bimiRouter,
   brain: brainRouter,
   categories: categoriesRouter,
   connections: connectionsRouter,

--- a/apps/server/src/trpc/routes/bimi.ts
+++ b/apps/server/src/trpc/routes/bimi.ts
@@ -1,0 +1,217 @@
+import { router, privateProcedure, createRateLimiterMiddleware } from '../trpc';
+import { Ratelimit } from '@upstash/ratelimit';
+import { z } from 'zod';
+
+const parseBimiRecord = (record: string) => {
+  const parts = record.split(';').map((part) => part.trim());
+  const result: { version?: string; logoUrl?: string; authorityUrl?: string } = {};
+
+  for (const part of parts) {
+    if (part.startsWith('v=')) {
+      result.version = part.substring(2);
+    } else if (part.startsWith('l=')) {
+      result.logoUrl = part.substring(2);
+    } else if (part.startsWith('a=')) {
+      result.authorityUrl = part.substring(2);
+    }
+  }
+
+  return result;
+};
+
+const fetchDnsRecord = async (domain: string): Promise<string | null> => {
+  try {
+    const response = await fetch(
+      `https://dns.google/resolve?name=default._bimi.${domain}&type=TXT`,
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      Status: number;
+      Answer?: Array<{ data: string }>;
+    };
+
+    if (data.Status !== 0 || !data.Answer || data.Answer.length === 0) {
+      return null;
+    }
+
+    const bimiRecord = data.Answer.find((answer) => answer.data.includes('v=BIMI1'));
+
+    if (!bimiRecord) {
+      return null;
+    }
+
+    return bimiRecord.data.replace(/"/g, '');
+  } catch (error) {
+    console.error(`Error fetching BIMI record for ${domain}:`, error);
+    return null;
+  }
+};
+
+const fetchLogoContent = async (logoUrl: string): Promise<string | null> => {
+  try {
+    const url = new URL(logoUrl);
+    if (url.protocol !== 'https:') {
+      return null;
+    }
+
+    const response = await fetch(logoUrl, {
+      headers: {
+        Accept: 'image/svg+xml',
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('svg')) {
+      return null;
+    }
+
+    const svgContent = await response.text();
+
+    if (!svgContent.includes('<svg') || !svgContent.includes('</svg>')) {
+      return null;
+    }
+
+    return svgContent;
+  } catch (error) {
+    console.error(`Error fetching logo from ${logoUrl}:`, error);
+    return null;
+  }
+};
+
+export const bimiRouter = router({
+  getByEmail: privateProcedure
+    .use(
+      createRateLimiterMiddleware({
+        generatePrefix: ({ sessionUser }) => `ratelimit:bimi-${sessionUser?.id}`,
+        limiter: Ratelimit.slidingWindow(30, '1m'),
+      }),
+    )
+    .input(
+      z.object({
+        email: z.string().email(),
+      }),
+    )
+    .output(
+      z.object({
+        domain: z.string(),
+        bimiRecord: z
+          .object({
+            version: z.string().optional(),
+            logoUrl: z.string().optional(),
+            authorityUrl: z.string().optional(),
+          })
+          .nullable(),
+        logo: z
+          .object({
+            url: z.string(),
+            svgContent: z.string(),
+          })
+          .nullable(),
+      }),
+    )
+    .query(async ({ input }) => {
+      const domain = input.email.split('@')[1];
+
+      if (!domain) {
+        throw new Error('Invalid email address');
+      }
+
+      const bimiRecordText = await fetchDnsRecord(domain);
+
+      if (!bimiRecordText) {
+        return {
+          domain,
+          bimiRecord: null,
+          logo: null,
+        };
+      }
+
+      const bimiRecord = parseBimiRecord(bimiRecordText);
+
+      let logo = null;
+      if (bimiRecord.logoUrl) {
+        const svgContent = await fetchLogoContent(bimiRecord.logoUrl);
+        if (svgContent) {
+          logo = {
+            url: bimiRecord.logoUrl,
+            svgContent,
+          };
+        }
+      }
+
+      return {
+        domain,
+        bimiRecord,
+        logo,
+      };
+    }),
+
+  getByDomain: privateProcedure
+    .use(
+      createRateLimiterMiddleware({
+        generatePrefix: ({ sessionUser }) => `ratelimit:bimi-domain-${sessionUser?.id}`,
+        limiter: Ratelimit.slidingWindow(30, '1m'),
+      }),
+    )
+    .input(
+      z.object({
+        domain: z.string().min(1),
+      }),
+    )
+    .output(
+      z.object({
+        domain: z.string(),
+        bimiRecord: z
+          .object({
+            version: z.string().optional(),
+            logoUrl: z.string().optional(),
+            authorityUrl: z.string().optional(),
+          })
+          .nullable(),
+        logo: z
+          .object({
+            url: z.string(),
+            svgContent: z.string(),
+          })
+          .nullable(),
+      }),
+    )
+    .query(async ({ input }) => {
+      const bimiRecordText = await fetchDnsRecord(input.domain);
+
+      if (!bimiRecordText) {
+        return {
+          domain: input.domain,
+          bimiRecord: null,
+          logo: null,
+        };
+      }
+
+      const bimiRecord = parseBimiRecord(bimiRecordText);
+
+      let logo = null;
+      if (bimiRecord.logoUrl) {
+        const svgContent = await fetchLogoContent(bimiRecord.logoUrl);
+        if (svgContent) {
+          logo = {
+            url: bimiRecord.logoUrl,
+            svgContent,
+          };
+        }
+      }
+
+      return {
+        domain: input.domain,
+        bimiRecord,
+        logo,
+      };
+    }),
+});

--- a/apps/server/src/trpc/routes/bimi.ts
+++ b/apps/server/src/trpc/routes/bimi.ts
@@ -1,5 +1,6 @@
 import { router, privateProcedure, createRateLimiterMiddleware } from '../trpc';
 import { Ratelimit } from '@upstash/ratelimit';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 const parseBimiRecord = (record: string) => {
@@ -121,7 +122,10 @@ export const bimiRouter = router({
       const domain = input.email.split('@')[1];
 
       if (!domain) {
-        throw new Error('Invalid email address');
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Unable to extract domain from email address',
+        });
       }
 
       const bimiRecordText = await fetchDnsRecord(domain);


### PR DESCRIPTION
# Implement BIMI Avatar Support for Email Logos

This PR adds support for Brand Indicators for Message Identification (BIMI) avatars in the mail interface. BIMI is an email specification that allows organizations to display their logos in supporting email clients by adding specific DNS records.

The implementation includes:
- New `BimiAvatar` component that fetches and displays BIMI logos from DNS records
- Server-side TRPC routes to fetch and validate BIMI records
- Integration of the component throughout the mail interface
- Fallback mechanisms when BIMI logos aren't available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced BIMI (Brand Indicators for Message Identification) avatar support, displaying brand logos or fallback initials for email senders and recipients.
  * Added a new avatar component that automatically fetches and displays BIMI logos when available.
  * Enhanced avatar rendering in mail lists and mail display views with improved fallback and styling.
  * Added backend support for querying BIMI DNS records and fetching SVG logos via a new API route.

* **Bug Fixes**
  * Improved reliability and consistency of avatar display, ensuring appropriate fallbacks if brand logos are unavailable.

* **Chores**
  * Updated backend to support BIMI logo lookups and retrieval for enhanced email branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->