### PR TITLE
fix: mail display avatar

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -1301,7 +1301,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
           >
             <div className="mt-3 flex w-full items-start justify-between gap-4 px-4">
               <div className="flex w-full justify-center gap-4">
-                <BimiAvatar email={emailData?.sender?.email} name={emailData?.sender?.name} />
+                <BimiAvatar
+                  email={emailData?.sender?.email}
+                  name={emailData?.sender?.name}
+                  className="mt-3 h-8 w-8"
+                />
 
                 <div className="flex w-full items-center justify-between">
                   <div className="flex w-full items-center justify-start">


### PR DESCRIPTION
## Description

Added specific styling to the BimiAvatar component in the mail display to ensure consistent sizing and proper vertical alignment. The avatar now has a fixed height and width of 8 units and a top margin of 3 units.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the avatar in mail display with improved spacing and consistent sizing for a more polished appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->