### PR TITLE
fix/label Refresh Issuse #1748

### DIFF
--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -172,7 +172,9 @@ export function NavMain({ items }: NavMainProps) {
   );
 
   const onSubmit = async (data: LabelType) => {
-    toast.promise(createLabel(data), {
+    toast.promise(createLabel(data).then(()=>{
+      refetch();
+    }), {
       loading: 'Creating label...',
       success: 'Label created successfully',
       error: 'Failed to create label',


### PR DESCRIPTION
## Description
Fix: Resolve issue #1748 – Label creation now auto-refreshes the list after successful mutation
Previously, the new label was added successfully but the label list did not update automatically, requiring a manual page refresh. This has been fixed by triggering a query refetch when the label creation promise resolves.


## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] User Interface/Experience
- [x] Data Storage/Management


## Testing Done

Describe the tests you've done:

- [x] Manual testing performed


## Security Considerations

- [x] No sensitive data is exposed

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] My changes generate no new warnings
- [x] All tests pass locally


## Additional Notes

This resolves issue #1748 where newly created labels did not appear automatically. The label list is now refreshed upon successful creation without requiring a manual page reload.

## Screenshots/Recordings

Add screenshots or recordings here if applicable.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
