### PR TITLE
Bug: Special folders (spam, archive, etc.) show mail count but no emails on page refresh

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -683,12 +683,9 @@ export const MailList = memo(
 
     const allCategories = Categories();
 
-    // Skip category filtering for drafts, spam, sent, archive, and bin pages
-    const shouldFilter = !['draft', 'spam', 'sent', 'archive', 'bin'].includes(folder || '');
 
-    // Set initial category search value only if not in special folders
+    // Set initial category search value
     useEffect(() => {
-      if (!shouldFilter) return;
 
       const currentCategory = category
         ? allCategories.find((cat) => cat.id === category)
@@ -701,7 +698,7 @@ export const MailList = memo(
           folder: '',
         });
       }
-    }, [allCategories, category, shouldFilter, searchValue.value, setSearchValue]);
+    }, [allCategories, category, searchValue.value, setSearchValue]);
 
     // Add event listener for refresh
     useEffect(() => {


### PR DESCRIPTION
### Description
When navigating to special folders like `/mail/spam`, `/mail/archive`, `/mail/sent`, `/mail/bin`, or `/mail/draft` and then refreshing the page, the interface shows the correct mail count but displays no actual emails in the list.

### Steps to Reproduce
1. Navigate to `/mail/inbox` (works correctly)
2. Navigate to `/mail/spam` or `/mail/archive` (works correctly)
3. Refresh the page while on `/mail/spam` or `/mail/archive`
4. **Expected**: Emails should be visible in the list
5. **Actual**: Mail count is shown but no emails appear in the list

### Root Cause
The issue was caused by category filtering logic that was preventing the search value from being set correctly for special folders. The `useEffect` that sets initial category search values was being skipped for special folders due to the `shouldFilter` condition, but this was also preventing the proper initialization of the search state.

### Impact
- Users cannot view emails in special folders after page refresh
- Inconsistent behavior between inbox and other folders

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] �� UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Screenshots/Recordings

**Before Fix:**
- Special folders would show mail count but no emails after page refresh

Video: https://www.loom.com/share/24d18b3ff8a249d5b185f21cea1842cd?sid=8abbc92e-ed4f-4aed-ab23-dd39630a7712

**After Fix:**
- Special folders now display emails correctly after page refresh
- All existing functionality remains intact

Video: https://www.loom.com/share/e71d4d9e9b8b4726833c381777891cac?sid=b58f3276-3d2d-4d05-8152-f0143c9e5437


fixes #1761 

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where special folders like spam, archive, sent, bin, and draft showed the correct mail count but no emails after a page refresh.

- **Bug Fixes**
  - Updated category filtering logic so emails in special folders display correctly after refreshing the page.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the logic for initializing the category search value so that it now applies to all folders, including drafts, spam, sent, archive, and bin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->