### PR TITLE
dont drop tables

### DIFF
--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -51,7 +51,6 @@ import { processToolCalls } from './utils';
 import { env } from 'cloudflare:workers';
 import type { Connection } from 'agents';
 import { openai } from '@ai-sdk/openai';
-import { parseISO } from 'date-fns';
 import { createDb } from '../../db';
 import { DriverRpcDO } from './rpc';
 import { eq } from 'drizzle-orm';
@@ -59,9 +58,9 @@ import { Effect } from 'effect';
 
 const decoder = new TextDecoder();
 
-const shouldDropTables = true;
+const shouldDropTables = false;
 const maxCount = 20;
-const shouldLoop = true;
+const shouldLoop = env.THREAD_SYNC_LOOP !== 'false';
 export class ZeroDriver extends AIChatAgent<typeof env> {
   private foldersInSync: Map<string, boolean> = new Map();
   private syncThreadsInProgress: Map<string, boolean> = new Map();

--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -258,7 +258,7 @@
         "DISABLE_CALLS": "",
         "DROP_AGENT_TABLES": "false",
         "THREAD_SYNC_MAX_COUNT": "20",
-        "THREAD_SYNC_LOOP": "false",
+        "THREAD_SYNC_LOOP": "true",
         "DISABLE_WORKFLOWS": "true",
       },
       "kv_namespaces": [


### PR DESCRIPTION
# Enable Thread Sync Loop by Default

## Description

This PR modifies the thread synchronization behavior by:

1. Setting `shouldDropTables` to `false` to prevent database tables from being dropped during sync operations
2. Making the `shouldLoop` variable read from the environment variable `THREAD_SYNC_LOOP` with a default of enabled
3. Updating the default value of `THREAD_SYNC_LOOP` to `true` in the wrangler configuration
4. Removing an unused import of `parseISO` from date-fns

These changes ensure that thread synchronization runs continuously by default while preserving database tables.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement

## Areas Affected

- [x] Data Storage/Management
- [x] Development Workflow

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

This change improves the reliability of thread synchronization by making it enabled by default and preventing accidental data loss from table drops.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._