### PR TITLE
fix: undefined name on specific platforms fixed

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ let args = [];
 if (process.argv.slice(2).length === 0) {
   intro(`Welcome to the Nizzy CLI`);
 
-  const user = process.env.USER || process.env.USERNAME;
+  const user = process.env.USER || process.env.USERNAME || 'there';
 
   const command = await select({
     message: `Hey ${user}, what do you want to do?`,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,8 +5,10 @@ let args = [];
 if (process.argv.slice(2).length === 0) {
   intro(`Welcome to the Nizzy CLI`);
 
+  const user = process.env.USER || process.env.USERNAME;
+
   const command = await select({
-    message: `Hey ${process.env.USER}, what do you want to do?`,
+    message: `Hey ${user}, what do you want to do?`,
     options: Object.values(commands).map((command) => ({
       label: command.description,
       value: command.id,


### PR DESCRIPTION
# Description
Fixes a bug where `process.env.USER` is undefined on Windows, causing the CLI to greet users with "**Hey undefined**". Added a fallback to use `process.env.USERNAME` to ensure a proper greeting across platforms when the command `pnpm nizzy` is ran.

# Type of Change
- Bug fix

# Areas affected 
- Development Workflow

# Screenshots

- Before the fix
<img width="736" height="248" alt="image" src="https://github.com/user-attachments/assets/c324dbed-d3bd-41c0-af72-79eab5209b34" />

- After the fix
<img width="740" height="197" alt="image" src="https://github.com/user-attachments/assets/d6cb5e5f-fb99-4b76-ae64-86cab483cfa2" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the CLI greeted users as "undefined" on Windows by falling back to process.env.USERNAME when process.env.USER is not set.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the consistency of user greeting messages in the interactive CLI by standardizing how the user's name is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->