### PR TITLE
Implement thread deletion functionality

### DIFF
--- a/apps/server/src/routes/agent/rpc.ts
+++ b/apps/server/src/routes/agent/rpc.ts
@@ -161,7 +161,9 @@ export class DriverRpcDO extends RpcTarget {
   }
 
   async delete(id: string) {
-    return await this.mainDo.delete(id);
+    const result = await this.mainDo.delete(id);
+    await this.mainDo.deleteThread(id);
+    return result;
   }
 
   async deleteAllSpam() {


### PR DESCRIPTION
# Implement Thread Deletion Functionality

## Description

This PR implements thread deletion functionality, allowing users to permanently delete threads from the bin. The implementation includes:

1. Replacing the optimistic delete with a real deletion using TRPC mutation
2. Enabling the previously disabled delete button in the thread context menu
3. Adding server-side support for thread deletion from the database
4. Adding folder name normalization to handle 'bin' vs 'trash' naming differences

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [x] Data Storage/Management

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The implementation now properly deletes threads from the database when the user selects the delete option from the context menu. The UI provides toast notifications to indicate the deletion status.

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._