### PR TITLE
feat: add google calendar integration

### DIFF
--- a/apps/mail/app/(routes)/settings/integrations/page.tsx
+++ b/apps/mail/app/(routes)/settings/integrations/page.tsx
@@ -83,7 +83,7 @@ export default function IntegrationsPage() {
       <h1 className="text-2xl font-semibold">Integrations</h1>
 
       {/* Debug Information */}
-      <div className="border border-yellow-500 rounded-lg p-4 bg-yellow-50 text-black dark:text-black">
+      {/* <div className="border border-yellow-500 rounded-lg p-4 bg-yellow-50 text-black dark:text-black">
         <h3 className="font-semibold text-yellow-800 mb-2">🐛 Debug Information</h3>
         <div className="text-sm space-y-1">
           <p><strong>Total Google connections:</strong> {googleConnections.length}</p>
@@ -104,7 +104,7 @@ export default function IntegrationsPage() {
             </div>
           )}
         </div>
-      </div>
+      </div> */}
 
       <div className="border rounded-lg p-6 flex items-center justify-between">
         <div>
@@ -157,7 +157,7 @@ export default function IntegrationsPage() {
           )}
         </div>
       </div>
-      <pre className="bg-gray-800 text-white p-4 rounded-lg overflow-x-auto text-xs">
+      {/* <pre className="bg-gray-800 text-white p-4 rounded-lg overflow-x-auto text-xs">
         {JSON.stringify({
           connections: data?.connections,
           googleConn,
@@ -169,7 +169,7 @@ export default function IntegrationsPage() {
           defaultConnection,
           googleConnections,
         }, null, 2)}
-      </pre>
+      </pre> */}
     </div>
   );
 } 

--- a/apps/mail/app/(routes)/settings/integrations/page.tsx
+++ b/apps/mail/app/(routes)/settings/integrations/page.tsx
@@ -1,0 +1,175 @@
+import { Button } from '@/components/ui/button';
+import { useConnections } from '@/hooks/use-connections';
+import { authClient } from '@/lib/auth-client';
+import { useTRPC } from '@/providers/query-provider';
+import { useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+export default function IntegrationsPage() {
+  const { data, isLoading, refetch } = useConnections();
+  const trpc = useTRPC();
+  const { mutateAsync: deleteConnection } = useMutation(trpc.connections.delete.mutationOptions());
+  const { mutateAsync: toggleCalendar } = useMutation(trpc.connections.toggleCalendar.mutationOptions());
+
+  const { data: defaultConnection } = useQuery(trpc.connections.getDefault.queryOptions());
+
+  const googleConnections = data?.connections?.filter((c: { providerId: string }) => c.providerId === 'google') || [];
+  const googleConn = googleConnections[0]; 
+
+  const isConnected = !!googleConn;
+  const scope = googleConn?.scope || '';
+  const hasCalendarScope = scope.includes('https://www.googleapis.com/auth/calendar') || scope.includes('https://www.googleapis.com/auth/calendar.events');
+
+  const calendarEnabled = googleConn?.calendarEnabled;
+
+  const upcomingQuery = useQuery(
+    trpc.calendar.upcoming.queryOptions(
+      { max: 5 },
+      {
+        enabled: hasCalendarScope && calendarEnabled,
+        staleTime: 1000 * 30,
+      },
+    ),
+  );
+
+  const {
+    data: upcomingData,
+    isLoading: loadingUpcoming,
+    error: upcomingError,
+  } = upcomingQuery as any;
+  const firstEvent = Array.isArray(upcomingData) && upcomingData.length ? upcomingData[0] : null;
+
+  const connect = () => {
+    authClient
+      .linkSocial({
+        provider: 'google',
+        callbackURL: `${window.location.origin}/settings/integrations`,
+        scopes: [
+          'https://www.googleapis.com/auth/calendar',
+        ],
+      })
+      .catch(console.error);
+  };
+
+  const disconnect = async () => {
+    if (!googleConn) return;
+
+    toast.promise(toggleCalendar({ connectionId: googleConn.id, enabled: false }), {
+      loading: 'Disconnecting...',
+      success: () => {
+        refetch();
+        return 'Disconnected successfully';
+      },
+      error: 'Failed to disconnect',
+    });
+  };
+
+  const enable = async () => {
+    if (!googleConn) return;
+
+    toast.promise(toggleCalendar({ connectionId: googleConn.id, enabled: true }), {
+      loading: 'Enabling...',
+      success: () => {
+        refetch();
+        return 'Enabled successfully';
+      },
+      error: 'Failed to enable',
+    });
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Integrations</h1>
+
+      {/* Debug Information */}
+      <div className="border border-yellow-500 rounded-lg p-4 bg-yellow-50 text-black dark:text-black">
+        <h3 className="font-semibold text-yellow-800 mb-2">🐛 Debug Information</h3>
+        <div className="text-sm space-y-1">
+          <p><strong>Total Google connections:</strong> {googleConnections.length}</p>
+          <p><strong>Active/Default connection ID:</strong> {defaultConnection?.id || 'None'}</p>
+          <p><strong>Active connection email:</strong> {defaultConnection?.email || 'None'}</p>
+
+          {googleConnections.length > 0 && (
+            <div className="mt-2">
+              <p><strong>All Google connections:</strong></p>
+              {googleConnections.map((conn: any, index: number) => (
+                <div key={conn.id} className="ml-4 p-2 border rounded mt-1 bg-white">
+                  <p>#{index + 1}: {conn.email} (ID: {conn.id})</p>
+                  <p>Has calendar: {conn.hasCalendar ? '✅' : '❌'}</p>
+                  <p>Scope: {conn.scope}</p>
+                  <p>Is active: {conn.id === defaultConnection?.id ? '✅ ACTIVE' : '❌'}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="border rounded-lg p-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-medium">Google Calendar</h2>
+
+          {!isConnected && <p className="text-sm text-gray-600">Connect your Google account.</p>}
+          {isConnected && !hasCalendarScope && (
+            <p className="text-sm text-yellow-600">
+              Calendar access not granted. Please grant access.
+            </p>
+          )}
+          {isConnected && hasCalendarScope && calendarEnabled && !loadingUpcoming && (
+            <p className="text-sm text-gray-600">Your Google Calendar is connected.</p>
+          )}
+          {isConnected && hasCalendarScope && !calendarEnabled && (
+            <p className="text-sm text-gray-600">Calendar integration is disabled.</p>
+          )}
+
+          {hasCalendarScope && calendarEnabled && !loadingUpcoming && firstEvent && (
+            <p className="text-sm mt-2">
+              Next event: <strong>{firstEvent.summary ?? 'No title'}</strong>{' '}
+              {firstEvent.start ? `at ${new Date(firstEvent.start).toLocaleString()}` : ''}
+            </p>
+          )}
+
+          {hasCalendarScope && calendarEnabled && !loadingUpcoming && !firstEvent && (
+            <p className="text-sm mt-2">No upcoming events found.</p>
+          )}
+
+          {upcomingError && (
+            <p className="text-sm text-red-500 mt-2">
+              Could not load events. Please try reconnecting.
+              <br />
+              <strong>Error:</strong> {String(upcomingError)}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {!isConnected && <Button onClick={connect}>Connect</Button>}
+          {isConnected && !hasCalendarScope && <Button onClick={connect}>Grant Access</Button>}
+          {isConnected && hasCalendarScope && calendarEnabled && (
+            <Button variant="destructive" onClick={disconnect}>
+              Disconnect
+            </Button>
+          )}
+          {isConnected && hasCalendarScope && !calendarEnabled && (
+            <Button onClick={enable}>
+              Enable
+            </Button>
+          )}
+        </div>
+      </div>
+      <pre className="bg-gray-800 text-white p-4 rounded-lg overflow-x-auto text-xs">
+        {JSON.stringify({
+          connections: data?.connections,
+          googleConn,
+          hasCalendar: googleConn?.hasCalendar,
+          connected: isConnected,
+          upcomingData: upcomingData ?? null,
+          loadingUpcoming,
+          upcomingError: upcomingError ?? null,
+          defaultConnection,
+          googleConnections,
+        }, null, 2)}
+      </pre>
+    </div>
+  );
+} 

--- a/apps/mail/app/routes.ts
+++ b/apps/mail/app/routes.ts
@@ -46,6 +46,7 @@ export default [
         // route('/categories', '(routes)/settings/categories/page.tsx'),
         route('/notifications', '(routes)/settings/notifications/page.tsx'),
         route('/organization', '(routes)/settings/organization/page.tsx'),
+        route('/integrations', '(routes)/settings/integrations/page.tsx'),
         route('/privacy', '(routes)/settings/privacy/page.tsx'),
         route('/security', '(routes)/settings/security/page.tsx'),
         route('/shortcuts', '(routes)/settings/shortcuts/page.tsx'),

--- a/apps/mail/config/navigation.ts
+++ b/apps/mail/config/navigation.ts
@@ -154,6 +154,11 @@ export const navigationConfig: Record<string, NavConfig> = {
             shortcut: 'g + s',
           },
           {
+            title: 'Integrations',
+            url: '/settings/integrations',
+            icon: SettingsGear,
+          },
+          {
             title: m['navigation.settings.connections'](),
             url: '/settings/connections',
             icon: Users,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,6 +55,7 @@
     "elevenlabs": "1.59.0",
     "email-addresses": "^5.0.0",
     "google-auth-library": "9.15.1",
+    "@googleapis/calendar": "11.0.1",
     "he": "^1.2.0",
     "hono": "^4.7.8",
     "hono-agents": "0.0.83",

--- a/apps/server/src/db/migrations/0045_workable_groot.sql
+++ b/apps/server/src/db/migrations/0045_workable_groot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mail0_connection" ADD COLUMN "calendar_enabled" boolean DEFAULT true NOT NULL;

--- a/apps/server/src/db/migrations/meta/0045_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0045_snapshot.json
@@ -1,0 +1,2060 @@
+{
+  "id": "64c78522-5265-49b5-9d9e-82b8384a46a2",
+  "prevId": "ac20c197-0a9d-45e8-a645-f3adf7dcdaf9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.mail0_account": {
+      "name": "mail0_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_user_id_idx": {
+          "name": "account_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_expires_at_idx": {
+          "name": "account_expires_at_idx",
+          "columns": [
+            {
+              "expression": "access_token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_account_user_id_mail0_user_id_fk": {
+          "name": "mail0_account_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_account",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_connection": {
+      "name": "mail0_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_enabled": {
+          "name": "calendar_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_user_id_idx": {
+          "name": "connection_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_expires_at_idx": {
+          "name": "connection_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_provider_id_idx": {
+          "name": "connection_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_connection_user_id_mail0_user_id_fk": {
+          "name": "mail0_connection_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_connection",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_connection_user_id_email_unique": {
+          "name": "mail0_connection_user_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_early_access": {
+      "name": "mail0_early_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_early_access": {
+          "name": "is_early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_used_ticket": {
+          "name": "has_used_ticket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "early_access_is_early_access_idx": {
+          "name": "early_access_is_early_access_idx",
+          "columns": [
+            {
+              "expression": "is_early_access",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_early_access_email_unique": {
+          "name": "mail0_early_access_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_invitation": {
+      "name": "mail0_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_invitation_organization_id_mail0_organization_id_fk": {
+          "name": "mail0_invitation_organization_id_mail0_organization_id_fk",
+          "tableFrom": "mail0_invitation",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail0_invitation_inviter_id_mail0_user_id_fk": {
+          "name": "mail0_invitation_inviter_id_mail0_user_id_fk",
+          "tableFrom": "mail0_invitation",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_jwks": {
+      "name": "mail0_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "jwks_created_at_idx": {
+          "name": "jwks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_member": {
+      "name": "mail0_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_member_organization_id_mail0_organization_id_fk": {
+          "name": "mail0_member_organization_id_mail0_organization_id_fk",
+          "tableFrom": "mail0_member",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail0_member_user_id_mail0_user_id_fk": {
+          "name": "mail0_member_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_member",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_note": {
+      "name": "mail0_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_user_id_idx": {
+          "name": "note_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_thread_id_idx": {
+          "name": "note_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_user_thread_idx": {
+          "name": "note_user_thread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_is_pinned_idx": {
+          "name": "note_is_pinned_idx",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_note_user_id_mail0_user_id_fk": {
+          "name": "mail0_note_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_note",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_oauth_access_token": {
+      "name": "mail0_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expires_at_idx": {
+          "name": "oauth_access_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "access_token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_oauth_access_token_access_token_unique": {
+          "name": "mail0_oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "mail0_oauth_access_token_refresh_token_unique": {
+          "name": "mail0_oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_oauth_application": {
+      "name": "mail0_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_u_r_ls": {
+          "name": "redirect_u_r_ls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_application_disabled_idx": {
+          "name": "oauth_application_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_oauth_application_client_id_unique": {
+          "name": "mail0_oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_oauth_consent": {
+      "name": "mail0_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_given_idx": {
+          "name": "oauth_consent_given_idx",
+          "columns": [
+            {
+              "expression": "consent_given",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_organization": {
+      "name": "mail0_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_organization_slug_unique": {
+          "name": "mail0_organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_organization_connection": {
+      "name": "mail0_organization_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_organization_connection_organizationId_mail0_organization_id_fk": {
+          "name": "mail0_organization_connection_organizationId_mail0_organization_id_fk",
+          "tableFrom": "mail0_organization_connection",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail0_organization_connection_connectionId_mail0_connection_id_fk": {
+          "name": "mail0_organization_connection_connectionId_mail0_connection_id_fk",
+          "tableFrom": "mail0_organization_connection",
+          "tableTo": "mail0_connection",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_organization_domain": {
+      "name": "mail0_organization_domain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_organization_domain_organizationId_mail0_organization_id_fk": {
+          "name": "mail0_organization_domain_organizationId_mail0_organization_id_fk",
+          "tableFrom": "mail0_organization_domain",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_session": {
+      "name": "mail0_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_session_user_id_mail0_user_id_fk": {
+          "name": "mail0_session_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_session",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail0_session_active_organization_id_mail0_organization_id_fk": {
+          "name": "mail0_session_active_organization_id_mail0_organization_id_fk",
+          "tableFrom": "mail0_session",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_session_token_unique": {
+          "name": "mail0_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_summary": {
+      "name": "mail0_summary",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved": {
+          "name": "saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_reply": {
+          "name": "suggested_reply",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "summary_connection_id_idx": {
+          "name": "summary_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_connection_id_saved_idx": {
+          "name": "summary_connection_id_saved_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "saved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "summary_saved_idx": {
+          "name": "summary_saved_idx",
+          "columns": [
+            {
+              "expression": "saved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_summary_connection_id_mail0_connection_id_fk": {
+          "name": "mail0_summary_connection_id_mail0_connection_id_fk",
+          "tableFrom": "mail0_summary",
+          "tableTo": "mail0_connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_team": {
+      "name": "mail0_team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_team_organization_id_mail0_organization_id_fk": {
+          "name": "mail0_team_organization_id_mail0_organization_id_fk",
+          "tableFrom": "mail0_team",
+          "tableTo": "mail0_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_user": {
+      "name": "mail0_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_connection_id": {
+          "name": "default_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_prompt": {
+          "name": "custom_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_user_email_unique": {
+          "name": "mail0_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "mail0_user_phone_number_unique": {
+          "name": "mail0_user_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_user_hotkeys": {
+      "name": "mail0_user_hotkeys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shortcuts": {
+          "name": "shortcuts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_hotkeys_shortcuts_idx": {
+          "name": "user_hotkeys_shortcuts_idx",
+          "columns": [
+            {
+              "expression": "shortcuts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_user_hotkeys_user_id_mail0_user_id_fk": {
+          "name": "mail0_user_hotkeys_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_user_hotkeys",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_user_settings": {
+      "name": "mail0_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"language\":\"en\",\"timezone\":\"UTC\",\"dynamicContent\":false,\"externalImages\":true,\"customPrompt\":\"\",\"trustedSenders\":[],\"isOnboarded\":false,\"colorTheme\":\"system\",\"zeroSignature\":true,\"autoRead\":true,\"defaultEmailAlias\":\"\",\"categories\":[{\"id\":\"Important\",\"name\":\"Important\",\"searchValue\":\"is:important NOT is:sent NOT is:draft\",\"order\":0,\"icon\":\"Lightning\",\"isDefault\":false},{\"id\":\"All Mail\",\"name\":\"All Mail\",\"searchValue\":\"NOT is:draft (is:inbox OR (is:sent AND to:me))\",\"order\":1,\"icon\":\"Mail\",\"isDefault\":true},{\"id\":\"Personal\",\"name\":\"Personal\",\"searchValue\":\"is:personal NOT is:sent NOT is:draft\",\"order\":2,\"icon\":\"User\",\"isDefault\":false},{\"id\":\"Promotions\",\"name\":\"Promotions\",\"searchValue\":\"is:promotions NOT is:sent NOT is:draft\",\"order\":3,\"icon\":\"Tag\",\"isDefault\":false},{\"id\":\"Updates\",\"name\":\"Updates\",\"searchValue\":\"is:updates NOT is:sent NOT is:draft\",\"order\":4,\"icon\":\"Bell\",\"isDefault\":false},{\"id\":\"Unread\",\"name\":\"Unread\",\"searchValue\":\"is:unread NOT is:sent NOT is:draft\",\"order\":5,\"icon\":\"ScanEye\",\"isDefault\":false}],\"imageCompression\":\"medium\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_settings_settings_idx": {
+          "name": "user_settings_settings_idx",
+          "columns": [
+            {
+              "expression": "settings",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_user_settings_user_id_mail0_user_id_fk": {
+          "name": "mail0_user_settings_user_id_mail0_user_id_fk",
+          "tableFrom": "mail0_user_settings",
+          "tableTo": "mail0_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_user_settings_user_id_unique": {
+          "name": "mail0_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_verification": {
+      "name": "mail0_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_writing_style_matrix": {
+      "name": "mail0_writing_style_matrix",
+      "schema": "",
+      "columns": {
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numMessages": {
+          "name": "numMessages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "writing_style_matrix_style_idx": {
+          "name": "writing_style_matrix_style_idx",
+          "columns": [
+            {
+              "expression": "style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail0_writing_style_matrix_connectionId_mail0_connection_id_fk": {
+          "name": "mail0_writing_style_matrix_connectionId_mail0_connection_id_fk",
+          "tableFrom": "mail0_writing_style_matrix",
+          "tableTo": "mail0_connection",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mail0_writing_style_matrix_connectionId_pk": {
+          "name": "mail0_writing_style_matrix_connectionId_pk",
+          "columns": [
+            "connectionId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1753184836309,
       "tag": "0044_lean_saracen",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1753357486090,
+      "tag": "0045_workable_groot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -132,6 +132,7 @@ export const connection = createTable(
     scope: text('scope').notNull(),
     providerId: text('provider_id').$type<'google' | 'microsoft'>().notNull(),
     expiresAt: timestamp('expires_at').notNull(),
+    calendarEnabled: boolean('calendar_enabled').notNull().default(true),
     createdAt: timestamp('created_at').notNull(),
     updatedAt: timestamp('updated_at').notNull(),
   },

--- a/apps/server/src/lib/auth-providers.ts
+++ b/apps/server/src/lib/auth-providers.ts
@@ -42,6 +42,7 @@ export const authProviders = (env: Record<string, string>): ProviderConfig[] => 
         'https://www.googleapis.com/auth/gmail.modify',
         'https://www.googleapis.com/auth/userinfo.profile',
         'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/calendar',
       ],
       clientId: env.GOOGLE_CLIENT_ID,
       clientSecret: env.GOOGLE_CLIENT_SECRET,

--- a/apps/server/src/lib/calendar/google-calendar.ts
+++ b/apps/server/src/lib/calendar/google-calendar.ts
@@ -12,13 +12,6 @@ export class GoogleCalendarManager {
   private cal: calendar_v3.Calendar;
 
   constructor(private options: GoogleCalendarManagerOptions) {
-    console.log('🐛 GoogleCalendarManager constructor:', {
-      refreshToken: options.refreshToken ? 'PRESENT' : 'MISSING',
-      scope: options.scope,
-      expectedScope: this.getScope(),
-      apiKey: env.GOOGLE_API_KEY ? 'PRESENT' : 'MISSING',
-    });
-
     this.auth = new OAuth2Client(env.GOOGLE_CLIENT_ID, env.GOOGLE_CLIENT_SECRET);
 
     this.auth.setCredentials({
@@ -66,14 +59,12 @@ export class GoogleCalendarManager {
   }
 
   public async getNextEvent() {
-    console.log('🐛 Getting next event...');
     try {
       const events = await this.listUpcomingEvents(1);
       const event = events[0] || null;
-      console.log('🐛 Next event result:', event ? 'FOUND' : 'NONE');
       return event;
     } catch (error: any) {
-      console.error('🐛 Error getting next event:', {
+      console.error('Error getting next event:', {
         message: error.message,
         status: error.response?.status,
         statusText: error.response?.statusText,
@@ -84,10 +75,8 @@ export class GoogleCalendarManager {
   }
 
   public async listUpcomingEvents(maxResults = 5) {
-    console.log('🐛 Listing upcoming events, maxResults:', maxResults);
     try {
       const accessToken = await this.auth.getAccessToken();
-      console.log('🐛 Access token:', accessToken.token ? 'PRESENT' : 'MISSING');
 
       const url = new URL('https://www.googleapis.com/calendar/v3/calendars/primary/events');
       url.searchParams.set('timeMin', new Date().toISOString());
@@ -96,28 +85,23 @@ export class GoogleCalendarManager {
       url.searchParams.set('orderBy', 'startTime');
       url.searchParams.set('key', env.GOOGLE_API_KEY);
 
-      console.log('🐛 Making direct API call to:', url.toString());
-
       const response = await fetch(url.toString(), {
         headers: {
-          'Authorization': `Bearer ${accessToken.token}`,
-          'Accept': 'application/json',
+          Authorization: `Bearer ${accessToken.token}`,
+          Accept: 'application/json',
         },
       });
 
-      console.log('🐛 Calendar API response status:', response.status);
-
       if (!response.ok) {
         const errorText = await response.text();
-        console.error('🐛 Calendar API error response:', errorText);
+        console.error('Calendar API error response:', errorText);
         throw new Error(`Calendar API error: ${response.status} ${response.statusText} - ${errorText}`);
       }
 
-      const data = await response.json() as { items?: any[] };
-      console.log('🐛 Found events:', data.items?.length || 0);
+      const data = await response.json<{ items?: any[] }>();
       return data.items ?? [];
     } catch (error: any) {
-      console.error('🐛 Error listing upcoming events:', {
+      console.error('Error listing upcoming events:', {
         message: error.message,
         status: error.response?.status,
         statusText: error.response?.statusText,

--- a/apps/server/src/lib/calendar/google-calendar.ts
+++ b/apps/server/src/lib/calendar/google-calendar.ts
@@ -1,0 +1,130 @@
+import { OAuth2Client } from 'google-auth-library';
+import { calendar, type calendar_v3 } from '@googleapis/calendar';
+import { env } from 'cloudflare:workers';
+
+export interface GoogleCalendarManagerOptions {
+  refreshToken: string;
+  scope: string;
+}
+
+export class GoogleCalendarManager {
+  private auth: OAuth2Client;
+  private cal: calendar_v3.Calendar;
+
+  constructor(private options: GoogleCalendarManagerOptions) {
+    console.log('🐛 GoogleCalendarManager constructor:', {
+      refreshToken: options.refreshToken ? 'PRESENT' : 'MISSING',
+      scope: options.scope,
+      expectedScope: this.getScope(),
+      apiKey: env.GOOGLE_API_KEY ? 'PRESENT' : 'MISSING',
+    });
+
+    this.auth = new OAuth2Client(env.GOOGLE_CLIENT_ID, env.GOOGLE_CLIENT_SECRET);
+
+    this.auth.setCredentials({
+      refresh_token: options.refreshToken,
+      scope: options.scope,
+    });
+
+
+    this.cal = calendar({ version: 'v3', auth: this.auth as unknown as any });
+  }
+
+  public getScope(): string {
+    return 'https://www.googleapis.com/auth/calendar';
+  }
+
+  public async createEvent(params: {
+    summary: string;
+    description?: string;
+    startDateTime: string;
+    endDateTime: string;
+    timeZone?: string;
+    attendees?: { email: string }[];
+  }) {
+    const {
+      summary,
+      description,
+      startDateTime,
+      endDateTime,
+      timeZone = 'UTC',
+      attendees = [],
+    } = params;
+
+    const response = await this.cal.events.insert({
+      calendarId: 'primary',
+      requestBody: {
+        summary,
+        description,
+        start: { dateTime: startDateTime, timeZone },
+        end: { dateTime: endDateTime, timeZone },
+        attendees,
+      },
+    });
+
+    return response.data;
+  }
+
+  public async getNextEvent() {
+    console.log('🐛 Getting next event...');
+    try {
+      const events = await this.listUpcomingEvents(1);
+      const event = events[0] || null;
+      console.log('🐛 Next event result:', event ? 'FOUND' : 'NONE');
+      return event;
+    } catch (error: any) {
+      console.error('🐛 Error getting next event:', {
+        message: error.message,
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+      });
+      throw error;
+    }
+  }
+
+  public async listUpcomingEvents(maxResults = 5) {
+    console.log('🐛 Listing upcoming events, maxResults:', maxResults);
+    try {
+      const accessToken = await this.auth.getAccessToken();
+      console.log('🐛 Access token:', accessToken.token ? 'PRESENT' : 'MISSING');
+
+      const url = new URL('https://www.googleapis.com/calendar/v3/calendars/primary/events');
+      url.searchParams.set('timeMin', new Date().toISOString());
+      url.searchParams.set('maxResults', maxResults.toString());
+      url.searchParams.set('singleEvents', 'true');
+      url.searchParams.set('orderBy', 'startTime');
+      url.searchParams.set('key', env.GOOGLE_API_KEY);
+
+      console.log('🐛 Making direct API call to:', url.toString());
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          'Authorization': `Bearer ${accessToken.token}`,
+          'Accept': 'application/json',
+        },
+      });
+
+      console.log('🐛 Calendar API response status:', response.status);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('🐛 Calendar API error response:', errorText);
+        throw new Error(`Calendar API error: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const data = await response.json() as { items?: any[] };
+      console.log('🐛 Found events:', data.items?.length || 0);
+      return data.items ?? [];
+    } catch (error: any) {
+      console.error('🐛 Error listing upcoming events:', {
+        message: error.message,
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        errors: error.response?.data?.error?.errors,
+      });
+      throw error;
+    }
+  }
+} 

--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -62,6 +62,7 @@ export class GoogleMailManager implements MailManager {
       'https://www.googleapis.com/auth/gmail.modify',
       'https://www.googleapis.com/auth/userinfo.profile',
       'https://www.googleapis.com/auth/userinfo.email',
+      'https://www.googleapis.com/auth/calendar',
     ].join(' ');
   }
   public async listHistory<T>(historyId: string): Promise<{ history: T[]; historyId: string }> {

--- a/apps/server/src/routes/agent/tools.ts
+++ b/apps/server/src/routes/agent/tools.ts
@@ -1,6 +1,10 @@
 import { composeEmail } from '../../trpc/routes/ai/compose';
 import { perplexity } from '@ai-sdk/perplexity';
 import { generateText, tool } from 'ai';
+import { createDb } from '../../db';
+import { connection } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+import { GoogleCalendarManager } from '../../lib/calendar/google-calendar';
 
 import { getZeroAgent } from '../../lib/server-utils';
 import { colors } from '../../lib/prompts';
@@ -350,6 +354,52 @@ const deleteLabel = (connectionId: string) =>
     },
   });
 
+  const createCalendarEventTool = (connectionId: string) =>
+    tool({
+      description: 'Create a Google Calendar event for the authenticated user',
+      parameters: z.object({
+        summary: z.string().describe('The title of the calendar event'),
+        description: z.string().optional().describe('The description of the event'),
+        start: z
+          .string()
+          .describe('Start date-time in ISO 8601 format, e.g., 2025-07-03T10:00:00'),
+        end: z
+          .string()
+          .describe('End date-time in ISO 8601 format, e.g., 2025-07-03T11:00:00'),
+        timeZone: z
+          .string()
+          .optional()
+          .describe('IANA timezone string, defaults to UTC'),
+        attendees: z
+          .array(z.string())
+          .optional()
+          .describe('Emails of attendees to invite'),
+      }),
+      execute: async ({ summary, description, start, end, timeZone = 'UTC', attendees }) => {
+        const { db, conn } = createDb(env.HYPERDRIVE.connectionString);
+        const connData = await db.query.connection.findFirst({
+          where: eq(connection.id, connectionId),
+        });
+        await conn.end();
+        if (!connData?.refreshToken) {
+          throw new Error('Google connection not found or missing refresh token');
+        }
+        const calendarManager = new GoogleCalendarManager({
+          refreshToken: connData.refreshToken,
+          scope: connData.scope,
+        });
+        const event = await calendarManager.createEvent({
+          summary,
+          description,
+          startDateTime: start,
+          endDateTime: end,
+          timeZone,
+          attendees: attendees?.map((email) => ({ email })) ?? [],
+        });
+        return { id: event.id, htmlLink: event.htmlLink };
+      },
+    });
+
 export const webSearch = () =>
   tool({
     description: 'Search the web for information using Perplexity AI',
@@ -388,6 +438,7 @@ export const tools = async (connectionId: string) => {
     [Tools.SendEmail]: sendEmail(connectionId),
     [Tools.CreateLabel]: createLabel(connectionId),
     [Tools.BulkDelete]: bulkDelete(connectionId),
+    [Tools.CreateCalendarEvent]: createCalendarEventTool(connectionId),
     [Tools.BulkArchive]: bulkArchive(connectionId),
     [Tools.DeleteLabel]: deleteLabel(connectionId),
     [Tools.WebSearch]: tool({

--- a/apps/server/src/trpc/index.ts
+++ b/apps/server/src/trpc/index.ts
@@ -10,6 +10,7 @@ import { draftsRouter } from './routes/drafts';
 import { labelsRouter } from './routes/label';
 import { notesRouter } from './routes/notes';
 import { brainRouter } from './routes/brain';
+import { calendarRouter } from './routes/calendar';
 import { userRouter } from './routes/user';
 import { teamRouter } from './routes/team';
 import { mailRouter } from './routes/mail';
@@ -29,6 +30,7 @@ export const appRouter = router({
   labels: labelsRouter,
   mail: mailRouter,
   notes: notesRouter,
+  calendar: calendarRouter,
   organization: organizationRouter,
   team: teamRouter,
   shortcut: shortcutRouter,

--- a/apps/server/src/trpc/routes/calendar.ts
+++ b/apps/server/src/trpc/routes/calendar.ts
@@ -1,0 +1,86 @@
+import { activeConnectionProcedure, router } from '../trpc';
+import { getZeroDB } from '../../lib/server-utils';
+import { GoogleCalendarManager } from '../../lib/calendar/google-calendar';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+export const calendarRouter = router({
+  nextEvent: activeConnectionProcedure
+    .input(z.void())
+    .query(async ({ ctx }) => {
+      const { activeConnection, sessionUser } = ctx;
+      if (activeConnection.providerId !== 'google') {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Google connection required' });
+      }
+
+      if (!activeConnection.calendarEnabled) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'CALENDAR_DISABLED' });
+      }
+
+      const db = await getZeroDB(sessionUser.id);
+      const connection = await db.findUserConnection(activeConnection.id);
+      if (!connection?.refreshToken || !connection.scope) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing refresh token or scope' });
+      }
+
+      const calendarManager = new GoogleCalendarManager({
+        refreshToken: connection.refreshToken,
+        scope: connection.scope,
+      });
+      const event = await calendarManager.getNextEvent();
+
+      if (!event) return null;
+
+      return {
+        id: event.id,
+        summary: event.summary,
+        description: event.description,
+        start: event.start?.dateTime || event.start?.date,
+        end: event.end?.dateTime || event.end?.date,
+        location: event.location,
+        link: event.htmlLink,
+      } as const;
+    }),
+  upcoming: activeConnectionProcedure
+    .input(z.object({ max: z.number().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const { activeConnection, sessionUser } = ctx;
+      if (activeConnection.providerId !== 'google') {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Google connection required' });
+      }
+
+      if (!activeConnection.calendarEnabled) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'CALENDAR_DISABLED' });
+      }
+
+      const db = await getZeroDB(sessionUser.id);
+      const connection = await db.findUserConnection(activeConnection.id);
+      if (!connection?.refreshToken) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing refresh token' });
+      }
+
+      const calendarManager = new GoogleCalendarManager({
+        refreshToken: connection.refreshToken,
+        scope: connection.scope,
+      });
+      let events;
+      try {
+        events = await calendarManager.listUpcomingEvents(input?.max ?? 5);
+      } catch (err: unknown) {
+        if ((err as { response?: { status?: number } }).response?.status === 403) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'INSUFFICIENT_CALENDAR_SCOPE' });
+        }
+        throw err;
+      }
+
+      return events.map((ev) => ({
+        id: ev.id,
+        summary: ev.summary,
+        description: ev.description,
+        start: ev.start?.dateTime || ev.start?.date,
+        end: ev.end?.dateTime || ev.end?.date,
+        location: ev.location,
+        link: ev.htmlLink,
+      }));
+    }),
+}); 

--- a/apps/server/src/trpc/routes/settings.ts
+++ b/apps/server/src/trpc/routes/settings.ts
@@ -16,7 +16,7 @@ export const settingsRouter = router({
 
       const { sessionUser } = ctx;
       const db = await getZeroDB(sessionUser.id);
-      const result: any = await db.findUserSettings();
+      const result = await db.findUserSettings();
 
       // Returning null here when there are no settings so we can use the default settings with timezone from the browser
       if (!result) return { settings: defaultUserSettings };
@@ -34,13 +34,16 @@ export const settingsRouter = router({
   save: privateProcedure.input(userSettingsSchema.partial()).mutation(async ({ ctx, input }) => {
     const { sessionUser } = ctx;
     const db = await getZeroDB(sessionUser.id);
-    const existingSettings: any = await db.findUserSettings();
+    const existingSettings = await db.findUserSettings();
 
     if (existingSettings) {
-      const newSettings: any = { ...(existingSettings.settings as UserSettings), ...input };
+      const newSettings: UserSettings = {
+        ...(existingSettings.settings as UserSettings),
+        ...input,
+      };
       await db.updateUserSettings(newSettings);
     } else {
-      await db.insertUserSettings({ ...(defaultUserSettings as any), ...input });
+      await db.insertUserSettings({ ...defaultUserSettings, ...input });
     }
 
     return { success: true };

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -229,6 +229,7 @@ export enum Tools {
   BulkDelete = 'bulkDelete',
   BulkArchive = 'bulkArchive',
   DeleteLabel = 'deleteLabel',
+  CreateCalendarEvent = 'createCalendarEvent',
   AskZeroMailbox = 'askZeroMailbox',
   AskZeroThread = 'askZeroThread',
   WebSearch = 'webSearch',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
       '@coinbase/cookie-manager':
         specifier: 1.1.8
         version: 1.1.8
+      '@googleapis/calendar':
+        specifier: 11.0.1
+        version: 11.0.1
       '@googleapis/gmail':
         specifier: 12.0.0
         version: 12.0.0
@@ -1792,6 +1795,10 @@ packages:
 
   '@fontsource-variable/geist@5.2.6':
     resolution: {integrity: sha512-Bt9pdD55Fojq4h9yFKQAzh5+Xj4tKFpwbcDzK6t5PPSH2GrjPoPqm6N8y+tK6vzwKZ9hHyaOz/tAbO9cQd9UFQ==}
+
+  '@googleapis/calendar@11.0.1':
+    resolution: {integrity: sha512-XR6/V8SjuOyGMMx5shcKB2Ouyqkw2OG5a1srCb6ifPkIJG5qu/aocQ4VVizPc89izgdCGaKqcSpRFNJUsUuizg==}
+    engines: {node: '>=12.0.0'}
 
   '@googleapis/gmail@12.0.0':
     resolution: {integrity: sha512-sMsgh7J4pRIzmgte4vPfcxBptKliquVXlc9nhIWvuDfdkEVkyP8yh5pkhAnZmStEF0I5iOI04zriAt4C98XhBw==}
@@ -5309,6 +5316,10 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -5962,6 +5973,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
@@ -6041,6 +6056,10 @@ packages:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
@@ -6098,9 +6117,17 @@ packages:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
 
+  gaxios@7.1.1:
+    resolution: {integrity: sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  gcp-metadata@7.0.1:
+    resolution: {integrity: sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -6193,6 +6220,10 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-auth-library@10.1.0:
+    resolution: {integrity: sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -6201,9 +6232,17 @@ packages:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
     engines: {node: '>=14'}
 
+  google-logging-utils@1.1.1:
+    resolution: {integrity: sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==}
+    engines: {node: '>=14'}
+
   googleapis-common@7.2.0:
     resolution: {integrity: sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==}
     engines: {node: '>=14.0.0'}
+
+  googleapis-common@8.0.2-rc.0:
+    resolution: {integrity: sha512-JTcxRvmFa9Ec1uyfMEimEMeeKq1sHNZX3vn2qmoUMtnvixXXvcqTcbDZvEZXkEWpGlPlOf4joyep6/qs0BrLyg==}
+    engines: {node: '>=18.0.0'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6218,6 +6257,10 @@ packages:
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -7197,6 +7240,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -9095,6 +9142,10 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -10125,6 +10176,12 @@ snapshots:
   '@fontsource-variable/geist-mono@5.2.6': {}
 
   '@fontsource-variable/geist@5.2.6': {}
+
+  '@googleapis/calendar@11.0.1':
+    dependencies:
+      googleapis-common: 8.0.2-rc.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@googleapis/gmail@12.0.0':
     dependencies:
@@ -13945,6 +14002,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -14754,6 +14813,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.4.8: {}
 
   fflate@0.7.4: {}
@@ -14835,6 +14899,10 @@ snapshots:
 
   formdata-node@6.0.3: {}
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
@@ -14889,6 +14957,14 @@ snapshots:
       - encoding
       - supports-color
 
+  gaxios@7.1.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1:
     dependencies:
       gaxios: 6.7.1
@@ -14896,6 +14972,14 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gcp-metadata@7.0.1:
+    dependencies:
+      gaxios: 7.1.1
+      google-logging-utils: 1.1.1
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
@@ -15008,6 +15092,18 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-auth-library@10.1.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.1
+      gcp-metadata: 7.0.1
+      google-logging-utils: 1.1.1
+      gtoken: 8.0.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -15022,6 +15118,8 @@ snapshots:
 
   google-logging-utils@0.0.2: {}
 
+  google-logging-utils@1.1.1: {}
+
   googleapis-common@7.2.0:
     dependencies:
       extend: 3.0.2
@@ -15032,6 +15130,16 @@ snapshots:
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  googleapis-common@8.0.2-rc.0:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.1
+      google-auth-library: 10.1.0
+      qs: 6.14.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
       - supports-color
 
   gopd@1.2.0: {}
@@ -15046,6 +15154,13 @@ snapshots:
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.1
+      jws: 4.0.0
+    transitivePeerDependencies:
       - supports-color
 
   has-bigints@1.1.0: {}
@@ -16130,6 +16245,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.19: {}
 
@@ -18385,6 +18506,8 @@ snapshots:
       - yaml
 
   w3c-keyname@2.2.8: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added Google Calendar integration, allowing users to connect their Google account and manage calendar events directly from the app.

- **New Features**
  - Added a settings page for managing integrations, including Google Calendar.
  - Enabled Google Calendar event creation and viewing for connected accounts.
  - Updated backend to support calendar event APIs and permissions.
  - Added database support for tracking calendar integration status.

<!-- End of auto-generated description by cubic. -->

