### PR TITLE
fix: add undo feature to reply mails and fix default mail for replies

### DIFF
--- a/apps/mail/hooks/use-undo-send.ts
+++ b/apps/mail/hooks/use-undo-send.ts
@@ -28,9 +28,9 @@ type SerializableEmailData = Omit<EmailData, 'attachments'> & {
   attachments: SerializedFile[];
 };
 
-type ReplyMode = 'reply' | 'replyAll' | 'forward';
+export type ReplyMode = 'reply' | 'replyAll' | 'forward';
 
-type UndoContext =
+export type UndoContext =
   | { kind: 'compose' }
   | {
       kind: 'reply';


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added undo send support for reply emails and fixed default recipient and subject selection when replying.

- **New Features**
  - Users can now undo sending reply and reply-all emails, restoring their draft and recipients.

- **Bug Fixes**
  - Reply and reply-all now correctly prefill the "To", "Cc", and subject fields based on the original message.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Undo Send now restores reply/forward drafts within threads, pre-filling message, recipients, subject prefixes (Re:/Fwd:), and attachments.
  - Reply composer now auto-generates accurate default recipients for Reply, Reply All, and Forward, and applies subject prefixes only when needed.

- Bug Fixes
  - Adds safeguards to prevent server-side errors when reading undo data and clears temporary undo data when the composer closes.
  - Improves post-undo navigation behavior between standalone compose and in-thread reply flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->