### PR TITLE
fix(email-utils): guard against invalid URL in List-Unsubscribe parsing

### DIFF
--- a/apps/server/src/lib/email-utils.test.ts
+++ b/apps/server/src/lib/email-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getListUnsubscribeAction } from './email-utils';
+
+describe('getListUnsubscribeAction', () => {
+  it('parses a valid http List-Unsubscribe URL', () => {
+    expect(
+      getListUnsubscribeAction({ listUnsubscribe: '<https://example.com/u?id=1>' }),
+    ).toEqual({ type: 'get', url: 'https://example.com/u?id=1', host: 'example.com' });
+  });
+
+  it('returns null for an angle-bracketed value that is not a valid URL', () => {
+    // Regression: previously threw `TypeError: Invalid URL` because the primary
+    // `new URL(match[1])` path had no try/catch, unlike the fallback path.
+    expect(getListUnsubscribeAction({ listUnsubscribe: '<here>' })).toBeNull();
+    expect(
+      getListUnsubscribeAction({ listUnsubscribe: 'Click <here> to unsubscribe' }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/lib/email-utils.ts
+++ b/apps/server/src/lib/email-utils.ts
@@ -45,7 +45,13 @@ export const getListUnsubscribeAction = ({
   }
 
   // NOTE: List-Unsubscribe can contain multiple URLs, but the spec says to process the first one we can.
-  const url = new URL(match[1]);
+  let url: URL;
+  try {
+    url = new URL(match[1]);
+  } catch {
+    // The angle-bracket content is not a valid URL (malformed or placeholder header).
+    return null;
+  }
 
   if (url.protocol.startsWith('http')) {
     return processHttpUrl(url, listUnsubscribePost);


### PR DESCRIPTION
## What's broken
`getListUnsubscribeAction` in `apps/server/src/lib/email-utils.ts` throws `TypeError: Invalid URL` on a malformed `List-Unsubscribe` header. The primary URL-parse path has no try/catch, while the fallback path already guards the same `new URL(...)` call — so a malformed header crashes instead of degrading gracefully.

## Why it happens
The primary branch calls `new URL(...)` on the extracted header value without catching the exception that an invalid URL throws; only the fallback branch was wrapped.

## Fix
Wrap the primary `new URL(...)` parse in the same try/catch the fallback uses, so a malformed `List-Unsubscribe` value is handled (falls through) instead of throwing.

## Test
Processing a malformed `List-Unsubscribe` header no longer throws and returns a safe result; a valid header still parses. Fails before, passes after.
