### PR TITLE
feat: add heuristic email auto-labeling

### DIFF
--- a/apps/mail/hooks/use-auto-label.ts
+++ b/apps/mail/hooks/use-auto-label.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/providers/query-provider';
+import { toast } from 'sonner';
+
+export function useAutoLabel(threadId?: string) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const classification = useQuery(
+    trpc.autoLabel.classify.queryOptions(
+      { threadId: threadId ?? '' },
+      {
+        enabled: Boolean(threadId),
+        staleTime: 5 * 60 * 1000,
+      },
+    ),
+  );
+  const applyMutation = useMutation(
+    trpc.autoLabel.apply.mutationOptions({
+      onSuccess: async (result) => {
+        if (result.applied) {
+          toast.success(`${result.labelName} label applied`);
+        } else {
+          toast.info(result.reason);
+        }
+        await Promise.all([
+          queryClient.invalidateQueries(trpc.autoLabel.classify.queryFilter()),
+          queryClient.invalidateQueries(trpc.labels.list.queryFilter()),
+          queryClient.invalidateQueries(trpc.mail.get.queryFilter()),
+          queryClient.invalidateQueries(trpc.mail.listThreads.infiniteQueryFilter()),
+        ]);
+      },
+      onError: (error) => {
+        toast.error(error.message || 'Failed to apply the suggested label');
+      },
+    }),
+  );
+
+  return {
+    ...classification,
+    applySuggestion: () => {
+      if (!threadId) return;
+      applyMutation.mutate({ threadId });
+    },
+    isApplying: applyMutation.isPending,
+  };
+}

--- a/apps/server/src/lib/ai-auto-labeling.ts
+++ b/apps/server/src/lib/ai-auto-labeling.ts
@@ -1,0 +1,298 @@
+import type { IGetThreadResponse } from './driver/types';
+import type { Label } from '../types';
+
+export const autoLabelDefinitions = {
+  octg: {
+    labelName: 'OCTG',
+    description:
+      'Pipe inventory, brokers, mills, tubular services, RFQs, OCTG sales, and purchasing.',
+  },
+  newsletters: {
+    labelName: 'Tools/Newsletters',
+    description:
+      'Product updates, newsletters, software tools, AI services, and recurring marketing.',
+  },
+  personal: {
+    labelName: 'Personal',
+    description: 'Direct personal correspondence, family, travel, appointments, and relationships.',
+  },
+  finance: {
+    labelName: 'Finance',
+    description:
+      'Banks, cards, invoices, subscriptions, receipts, taxes, investing, and personal finance.',
+  },
+  spam: {
+    labelName: 'SPAM',
+    description: 'Provider-confirmed spam or messages with strong unsolicited-risk signals.',
+  },
+} as const;
+
+export type AutoLabelCategory = keyof typeof autoLabelDefinitions;
+export type AutoLabelClassification = {
+  category: AutoLabelCategory | 'none';
+  labelName: string | null;
+  confidence: number;
+  reason: string;
+  scores: Record<AutoLabelCategory, number>;
+};
+
+type WeightedPattern = {
+  label: string;
+  pattern: RegExp;
+  weight: number;
+};
+
+const patterns: Record<AutoLabelCategory, WeightedPattern[]> = {
+  octg: [
+    { label: 'OCTG', pattern: /\boctg\b/i, weight: 5 },
+    { label: 'tubular', pattern: /\btubular(?:s|\s+services?)?\b/i, weight: 4 },
+    { label: 'casing or tubing', pattern: /\b(?:casing|production tubing)\b/i, weight: 3 },
+    { label: 'drill or line pipe', pattern: /\b(?:drill|line)\s+pipe\b/i, weight: 3 },
+    { label: 'pipe inventory', pattern: /\bpipe\s+(?:inventory|yard|broker|mill)\b/i, weight: 3 },
+    { label: 'pipe grade', pattern: /\b(?:p110|l80|n80|j55|api\s+5ct)\b/i, weight: 3 },
+    {
+      label: 'pipe components',
+      pattern: /\b(?:pup joint|coupling|thread protector)\b/i,
+      weight: 3,
+    },
+    { label: 'RFQ', pattern: /\b(?:rfq|request for quote)\b/i, weight: 2 },
+  ],
+  newsletters: [
+    { label: 'newsletter', pattern: /\bnewsletter\b/i, weight: 3 },
+    { label: 'digest', pattern: /\b(?:daily|weekly|monthly)?\s*digest\b/i, weight: 2 },
+    { label: 'product update', pattern: /\bproduct\s+(?:update|news|release)\b/i, weight: 2 },
+    { label: 'webinar', pattern: /\bwebinar\b/i, weight: 2 },
+    {
+      label: 'marketing offer',
+      pattern: /\b(?:sale|promo code|special offer|limited time)\b/i,
+      weight: 2,
+    },
+    { label: 'unsubscribe', pattern: /\bunsubscribe\b/i, weight: 2 },
+  ],
+  personal: [
+    { label: 'personal greeting', pattern: /\b(?:hi|hey|hello)\s+mason\b/i, weight: 2 },
+    { label: 'family', pattern: /\b(?:family|mom|dad|brother|sister)\b/i, weight: 3 },
+    {
+      label: 'personal plans',
+      pattern: /\b(?:dinner|birthday|wedding|weekend|catch up)\b/i,
+      weight: 2,
+    },
+    { label: 'travel plans', pattern: /\b(?:flight|hotel|trip|vacation|itinerary)\b/i, weight: 2 },
+    { label: 'appointment', pattern: /\bappointment\b/i, weight: 2 },
+  ],
+  finance: [
+    { label: 'invoice', pattern: /\b(?:invoice|receipt|statement)\b/i, weight: 3 },
+    { label: 'payment', pattern: /\b(?:payment|transaction|deposit|withdrawal)\b/i, weight: 2 },
+    {
+      label: 'banking',
+      pattern: /\b(?:bank|credit card|debit card|checking|savings)\b/i,
+      weight: 3,
+    },
+    { label: 'subscription billing', pattern: /\b(?:subscription|renewal|billing)\b/i, weight: 2 },
+    { label: 'tax or payroll', pattern: /\b(?:tax|irs|payroll|w-?2|1099)\b/i, weight: 3 },
+    {
+      label: 'investing',
+      pattern: /\b(?:brokerage|portfolio|dividend|robinhood|origin financial)\b/i,
+      weight: 3,
+    },
+  ],
+  spam: [
+    {
+      label: 'credential lure',
+      pattern: /\b(?:verify your account|password expires?|unusual login)\b/i,
+      weight: 3,
+    },
+    {
+      label: 'prize lure',
+      pattern: /\b(?:you(?:'|\u2019)ve won|claim your prize|lottery winner)\b/i,
+      weight: 4,
+    },
+    {
+      label: 'high-pressure offer',
+      pattern: /\b(?:act now|urgent action required|risk[- ]free)\b/i,
+      weight: 2,
+    },
+    {
+      label: 'crypto solicitation',
+      pattern: /\b(?:guaranteed returns?|crypto giveaway)\b/i,
+      weight: 3,
+    },
+  ],
+};
+
+const categoryPriority: AutoLabelCategory[] = [
+  'spam',
+  'octg',
+  'finance',
+  'newsletters',
+  'personal',
+];
+
+const roundConfidence = (value: number) => Math.round(value * 100) / 100;
+
+export function hasProviderSpamLabel(thread: IGetThreadResponse) {
+  return [
+    ...thread.labels.flatMap((label) => [label.id, label.name]),
+    ...thread.messages.flatMap((message) => message.tags.flatMap((tag) => [tag.id, tag.name])),
+  ].some((label) => label.toUpperCase() === 'SPAM');
+}
+
+export function classifyThread(thread: IGetThreadResponse): AutoLabelClassification {
+  const scores: Record<AutoLabelCategory, number> = {
+    octg: 0,
+    newsletters: 0,
+    personal: 0,
+    finance: 0,
+    spam: 0,
+  };
+  const matches = new Map<AutoLabelCategory, string[]>();
+  const messages = thread.messages.filter((message) => !message.isDraft);
+
+  if (hasProviderSpamLabel(thread)) {
+    return {
+      category: 'spam',
+      labelName: autoLabelDefinitions.spam.labelName,
+      confidence: 0.99,
+      reason: 'Gmail already marked this thread as spam.',
+      scores: { ...scores, spam: 10 },
+    };
+  }
+
+  const searchableText = messages
+    .map((message) =>
+      [
+        message.subject,
+        message.title,
+        message.sender.name,
+        message.sender.email,
+        message.decodedBody,
+        message.body,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    )
+    .join(' ');
+
+  for (const category of categoryPriority) {
+    const categoryMatches: string[] = [];
+    for (const candidate of patterns[category]) {
+      if (candidate.pattern.test(searchableText)) {
+        scores[category] += candidate.weight;
+        categoryMatches.push(candidate.label);
+      }
+    }
+    matches.set(category, categoryMatches);
+  }
+
+  if (messages.some((message) => message.listUnsubscribe || message.listUnsubscribePost)) {
+    scores.newsletters += 4;
+    matches.set('newsletters', ['mailing-list headers', ...(matches.get('newsletters') ?? [])]);
+  }
+
+  const hasAutomatedSender = messages.some((message) =>
+    /\b(?:no-?reply|notifications?|mailer|marketing)\b/i.test(message.sender.email),
+  );
+  if (hasAutomatedSender) scores.newsletters += 1;
+
+  const ranked = categoryPriority
+    .map((category) => ({ category, score: scores[category] }))
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        categoryPriority.indexOf(a.category) - categoryPriority.indexOf(b.category),
+    );
+  const winner = ranked[0];
+  const runnerUp = ranked[1];
+
+  if (!winner || winner.score < 2) {
+    return {
+      category: 'none',
+      labelName: null,
+      confidence: 0,
+      reason: 'No category passed the minimum heuristic score.',
+      scores,
+    };
+  }
+
+  const margin = winner.score - (runnerUp?.score ?? 0);
+  const confidence = roundConfidence(Math.min(0.98, 0.5 + winner.score * 0.06 + margin * 0.04));
+  const matchedSignals = (matches.get(winner.category) ?? []).slice(0, 3);
+
+  return {
+    category: winner.category,
+    labelName: autoLabelDefinitions[winner.category].labelName,
+    confidence,
+    reason: matchedSignals.length
+      ? `Matched ${matchedSignals.join(', ')}.`
+      : `Matched ${autoLabelDefinitions[winner.category].description}`,
+    scores,
+  };
+}
+
+export interface AutoLabelAgent {
+  getUserLabels(): Promise<Label[]>;
+  createLabel(params: { name: string }): Promise<unknown>;
+  applyAutoLabel(
+    threadId: string,
+    addLabelIds: string[],
+    removeLabelIds: string[],
+  ): Promise<unknown>;
+}
+
+export async function applyAutoLabelClassification(
+  agent: AutoLabelAgent,
+  threadId: string,
+  classification: AutoLabelClassification,
+  currentLabelIds: string[],
+) {
+  if (classification.category === 'none' || !classification.labelName) {
+    return { applied: false, reason: 'No label was suggested.' };
+  }
+
+  let accountLabels = await agent.getUserLabels();
+  let targetLabel = accountLabels.find(
+    (label) => label.name.toLowerCase() === classification.labelName?.toLowerCase(),
+  );
+
+  if (!targetLabel && classification.category !== 'spam') {
+    await agent.createLabel({ name: classification.labelName });
+    accountLabels = await agent.getUserLabels();
+    targetLabel = accountLabels.find(
+      (label) => label.name.toLowerCase() === classification.labelName?.toLowerCase(),
+    );
+  }
+
+  if (!targetLabel) {
+    throw new Error(`Unable to find or create label "${classification.labelName}"`);
+  }
+
+  const managedNames = new Set(
+    Object.values(autoLabelDefinitions)
+      .filter((definition) => definition.labelName !== 'SPAM')
+      .map((definition) => definition.labelName.toLowerCase()),
+  );
+  const managedIds = new Set(
+    accountLabels
+      .filter((label) => managedNames.has(label.name.toLowerCase()))
+      .map((label) => label.id),
+  );
+  const addLabelIds = currentLabelIds.includes(targetLabel.id) ? [] : [targetLabel.id];
+  const removeLabelIds =
+    classification.category === 'spam'
+      ? []
+      : currentLabelIds.filter((id) => managedIds.has(id) && id !== targetLabel.id);
+
+  if (!addLabelIds.length && !removeLabelIds.length) {
+    return { applied: false, reason: 'The suggested label is already applied.' };
+  }
+
+  await agent.applyAutoLabel(threadId, addLabelIds, removeLabelIds);
+
+  return {
+    applied: true,
+    labelId: targetLabel.id,
+    labelName: targetLabel.name,
+    addLabelIds,
+    removeLabelIds,
+  };
+}

--- a/apps/server/src/routes/agent/rpc.ts
+++ b/apps/server/src/routes/agent/rpc.ts
@@ -121,6 +121,11 @@ export class DriverRpcDO extends RpcTarget {
     return result;
   }
 
+  async applyAutoLabel(threadId: string, addLabelIds: string[], removeLabelIds: string[]) {
+    await this.mainDo.modifyLabels([threadId], addLabelIds, removeLabelIds);
+    return await this.mainDo.modifyThreadLabelsInDB(threadId, addLabelIds, removeLabelIds);
+  }
+
   async createDraft(draftData: CreateDraftData) {
     return await this.mainDo.createDraft(draftData);
   }

--- a/apps/server/src/thread-workflow-utils/workflow-functions.ts
+++ b/apps/server/src/thread-workflow-utils/workflow-functions.ts
@@ -1,14 +1,19 @@
 import {
+  applyAutoLabelClassification,
+  autoLabelDefinitions,
+  classifyThread,
+  hasProviderSpamLabel,
+} from '../lib/ai-auto-labeling';
+import {
   SummarizeMessage,
-  ThreadLabels,
   ReSummarizeThread,
   SummarizeThread,
 } from '../lib/brain.fallback.prompts';
-import { EPrompts, defaultLabels, type ParsedMessage } from '../types';
 import { analyzeEmailIntent, generateAutomaticDraft } from './index';
 import { getPrompt, getEmbeddingVector } from '../pipelines.effect';
 import { messageToXML, threadToXML } from './workflow-utils';
 import type { WorkflowContext } from './workflow-engine';
+import { EPrompts, type ParsedMessage } from '../types';
 import { bulkDeleteKeys } from '../lib/bulk-delete';
 import { getZeroAgent } from '../lib/server-utils';
 import { getPromptName } from '../pipelines';
@@ -393,132 +398,56 @@ export const workflowFunctions: Record<string, WorkflowFunction> = {
   },
 
   generateLabels: async (context) => {
-    const summaryResult = context.results?.get('generate-thread-summary');
-    console.log(summaryResult, context.results);
-    if (!summaryResult?.summary) {
-      console.log('[WORKFLOW_FUNCTIONS] No summary available for label generation');
-      return { labels: [] };
-    }
+    const classification = classifyThread(context.thread);
+    const userLabels = Object.values(autoLabelDefinitions).map((definition) => ({
+      name: definition.labelName,
+      usecase: definition.description,
+    }));
 
-    console.log('[WORKFLOW_FUNCTIONS] Getting user topics for connection:', context.connectionId);
-    let userLabels: { name: string; usecase: string }[] = [];
-    try {
-      const agent = await getZeroAgent(context.connectionId);
-      const userTopics = await agent.getUserTopics();
-      if (userTopics.length > 0) {
-        userLabels = userTopics.map((topic: any) => ({
-          name: topic.topic,
-          usecase: topic.usecase,
-        }));
-        console.log('[WORKFLOW_FUNCTIONS] Using user topics as labels:', userLabels);
-      } else {
-        console.log('[WORKFLOW_FUNCTIONS] No user topics found, using defaults');
-        userLabels = defaultLabels;
-      }
-    } catch (error) {
-      console.log('[WORKFLOW_FUNCTIONS] Failed to get user topics, using defaults:', error);
-      userLabels = defaultLabels;
-    }
-
-    console.log('[WORKFLOW_FUNCTIONS] Generating labels for thread:', {
-      userLabels,
+    console.log('[WORKFLOW_FUNCTIONS] Auto-label classification:', {
       threadId: context.threadId,
-      threadLabels: context.thread.labels,
+      classification,
     });
 
-    const labelsResponse = await env.AI.run('@cf/meta/llama-4-scout-17b-16e-instruct', {
-      messages: [
-        { role: 'system', content: ThreadLabels(userLabels, context.thread.labels) },
-        { role: 'user', content: summaryResult.summary },
-      ],
-    });
-
-    if (labelsResponse?.response?.replaceAll('!', '').trim()?.length) {
-      console.log('[WORKFLOW_FUNCTIONS] Labels generated:', labelsResponse.response);
-      const labels: string[] = labelsResponse?.response
-        ?.split(',')
-        .map((e: string) => e.trim())
-        .filter((e: string) => e.length > 0)
-        .filter((e: string) =>
-          userLabels.find((label) => label.name.toLowerCase() === e.toLowerCase()),
-        );
-      return { labels, userLabelsUsed: userLabels };
-    } else {
-      console.log('[WORKFLOW_FUNCTIONS] No labels generated');
-      return { labels: [], userLabelsUsed: userLabels };
-    }
+    return {
+      labels:
+        classification.labelName &&
+        (classification.category !== 'spam' || hasProviderSpamLabel(context.thread))
+          ? [classification.labelName]
+          : [],
+      classification,
+      userLabelsUsed: userLabels,
+    };
   },
 
   applyLabels: async (context) => {
     const labelsResult = context.results?.get('generate-labels');
-    const userLabelsResult = context.results?.get('get-user-labels');
-
     if (!labelsResult?.labels || labelsResult.labels.length === 0) {
       console.log('[WORKFLOW_FUNCTIONS] No labels to apply');
       return { applied: false };
     }
 
-    if (!userLabelsResult?.userAccountLabels) {
-      console.log('[WORKFLOW_FUNCTIONS] No user account labels available');
+    if (!labelsResult.classification) {
+      console.log('[WORKFLOW_FUNCTIONS] No classification available');
       return { applied: false };
     }
 
-    const userAccountLabels = userLabelsResult.userAccountLabels;
-    const generatedLabels = labelsResult.labels;
-
-    console.log('[WORKFLOW_FUNCTIONS] Modifying thread labels:', generatedLabels);
-
     const agent = await getZeroAgent(context.connectionId);
+    const currentLabelIds = [
+      ...new Set([
+        ...context.thread.labels.map((label) => label.id),
+        ...context.thread.messages.flatMap((message) => message.tags.map((tag) => tag.id)),
+      ]),
+    ];
+    const result = await applyAutoLabelClassification(
+      agent,
+      context.threadId.toString(),
+      labelsResult.classification,
+      currentLabelIds,
+    );
 
-    const validLabelIds = generatedLabels
-      .map((name: string) => {
-        const foundLabel = userAccountLabels.find(
-          (label: { name: string; id: string }) => label.name.toLowerCase() === name.toLowerCase(),
-        );
-        return foundLabel?.id;
-      })
-      .filter((id: string | undefined): id is string => id !== undefined && id !== '');
-
-    if (validLabelIds.length > 0) {
-      const currentLabelIds = context.thread.labels?.map((l: { id: string }) => l.id) || [];
-      const labelsToAdd = validLabelIds.filter((id: string) => !currentLabelIds.includes(id));
-
-      const aiManagedLabelNames = new Set(
-        (labelsResult.userLabelsUsed || []).map((topic: { name: string }) =>
-          topic.name.toLowerCase(),
-        ),
-      );
-
-      const aiManagedLabelIds = new Set(
-        userAccountLabels
-          .filter((label: { name: string }) => aiManagedLabelNames.has(label.name.toLowerCase()))
-          .map((label: { id: string }) => label.id),
-      );
-
-      const labelsToRemove = currentLabelIds.filter(
-        (id: string) => aiManagedLabelIds.has(id) && !validLabelIds.includes(id),
-      );
-
-      if (labelsToAdd.length > 0 || labelsToRemove.length > 0) {
-        console.log('[WORKFLOW_FUNCTIONS] Applying label changes:', {
-          add: labelsToAdd,
-          remove: labelsToRemove,
-        });
-        await agent.modifyThreadLabelsInDB(
-          context.threadId.toString(),
-          labelsToAdd,
-          labelsToRemove,
-        );
-        console.log('[WORKFLOW_FUNCTIONS] Successfully modified thread labels');
-        return { applied: true, added: labelsToAdd.length, removed: labelsToRemove.length };
-      } else {
-        console.log('[WORKFLOW_FUNCTIONS] No label changes needed - labels already match');
-        return { applied: false };
-      }
-    }
-
-    console.log('[WORKFLOW_FUNCTIONS] No valid labels found in user account');
-    return { applied: false };
+    console.log('[WORKFLOW_FUNCTIONS] Auto-label application result:', result);
+    return result;
   },
 };
 

--- a/apps/server/src/trpc/index.ts
+++ b/apps/server/src/trpc/index.ts
@@ -1,6 +1,9 @@
 import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import { cookiePreferencesRouter } from './routes/cookies';
 import { connectionsRouter } from './routes/connections';
+import { categoriesRouter } from './routes/categories';
+import { autoLabelRouter } from './routes/auto-label';
+import { templatesRouter } from './routes/templates';
 import { shortcutRouter } from './routes/shortcut';
 import { settingsRouter } from './routes/settings';
 import { getContext } from 'hono/context-storage';
@@ -14,11 +17,10 @@ import { bimiRouter } from './routes/bimi';
 import type { HonoContext } from '../ctx';
 import { aiRouter } from './routes/ai';
 import { router } from './trpc';
-import { categoriesRouter } from './routes/categories';
-import { templatesRouter } from './routes/templates';
 
 export const appRouter = router({
   ai: aiRouter,
+  autoLabel: autoLabelRouter,
   bimi: bimiRouter,
   brain: brainRouter,
   categories: categoriesRouter,

--- a/apps/server/src/trpc/routes/auto-label.ts
+++ b/apps/server/src/trpc/routes/auto-label.ts
@@ -1,0 +1,65 @@
+import { applyAutoLabelClassification, classifyThread } from '../../lib/ai-auto-labeling';
+import { activeDriverProcedure, router } from '../trpc';
+import { getZeroAgent } from '../../lib/server-utils';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+const threadInput = z.object({
+  threadId: z.string().min(1),
+});
+
+export const autoLabelRouter = router({
+  classify: activeDriverProcedure.input(threadInput).query(async ({ ctx, input }) => {
+    const agent = await getZeroAgent(ctx.activeConnection.id);
+    const thread = await agent.getThread(input.threadId);
+
+    if (!thread.messages.length) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Thread is not available locally yet.',
+      });
+    }
+
+    const classification = classifyThread(thread);
+    const appliedLabelNames = new Set(
+      [
+        ...thread.labels.map((label) => label.name),
+        ...thread.messages.flatMap((message) => message.tags.map((tag) => tag.name)),
+      ].map((name) => name.toLowerCase()),
+    );
+
+    return {
+      ...classification,
+      alreadyApplied: classification.labelName
+        ? appliedLabelNames.has(classification.labelName.toLowerCase())
+        : false,
+    };
+  }),
+  apply: activeDriverProcedure.input(threadInput).mutation(async ({ ctx, input }) => {
+    const agent = await getZeroAgent(ctx.activeConnection.id);
+    const thread = await agent.getThread(input.threadId);
+
+    if (!thread.messages.length) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Thread is not available locally yet.',
+      });
+    }
+
+    const classification = classifyThread(thread);
+    const currentLabelIds = [
+      ...new Set([
+        ...thread.labels.map((label) => label.id),
+        ...thread.messages.flatMap((message) => message.tags.map((tag) => tag.id)),
+      ]),
+    ];
+    const result = await applyAutoLabelClassification(
+      agent,
+      input.threadId,
+      classification,
+      currentLabelIds,
+    );
+
+    return { classification, ...result };
+  }),
+});

--- a/apps/server/tests/ai-auto-labeling.test.ts
+++ b/apps/server/tests/ai-auto-labeling.test.ts
@@ -1,0 +1,151 @@
+import {
+  applyAutoLabelClassification,
+  classifyThread,
+  type AutoLabelAgent,
+} from '../src/lib/ai-auto-labeling';
+import type { IGetThreadResponse } from '../src/lib/driver/types';
+import { describe, expect, it } from 'vitest';
+
+function makeThread(overrides: {
+  subject?: string;
+  body?: string;
+  sender?: string;
+  listUnsubscribe?: string;
+  labels?: { id: string; name: string }[];
+}): IGetThreadResponse {
+  const labels = overrides.labels ?? [];
+  return {
+    messages: [
+      {
+        id: 'message-1',
+        title: overrides.subject ?? '',
+        subject: overrides.subject ?? '',
+        tags: labels.map((label) => ({ ...label, type: 'user' })),
+        sender: { email: overrides.sender ?? 'sender@example.com' },
+        to: [{ email: 'mason@example.com' }],
+        cc: null,
+        bcc: null,
+        tls: true,
+        listUnsubscribe: overrides.listUnsubscribe,
+        receivedOn: new Date().toISOString(),
+        unread: true,
+        body: overrides.body ?? '',
+        processedHtml: '',
+        blobUrl: '',
+        threadId: 'thread-1',
+      },
+    ],
+    latest: undefined,
+    hasUnread: true,
+    totalReplies: 1,
+    labels,
+  };
+}
+
+describe('classifyThread', () => {
+  it('prioritizes OCTG-specific language', () => {
+    const result = classifyThread(
+      makeThread({
+        subject: 'RFQ for API 5CT P110 casing',
+        body: 'Please quote the OCTG inventory at your pipe yard.',
+      }),
+    );
+
+    expect(result.category).toBe('octg');
+    expect(result.labelName).toBe('OCTG');
+  });
+
+  it('detects newsletters from mailing-list headers', () => {
+    const result = classifyThread(
+      makeThread({
+        subject: 'Weekly product digest',
+        listUnsubscribe: 'https://example.com/unsubscribe',
+      }),
+    );
+
+    expect(result.category).toBe('newsletters');
+    expect(result.labelName).toBe('Tools/Newsletters');
+  });
+
+  it('detects finance messages', () => {
+    const result = classifyThread(
+      makeThread({
+        subject: 'Your monthly credit card statement',
+        body: 'A payment was posted to your account.',
+      }),
+    );
+
+    expect(result.category).toBe('finance');
+  });
+
+  it('detects personal correspondence', () => {
+    const result = classifyThread(
+      makeThread({
+        subject: 'Dinner this weekend',
+        body: 'Hi Mason, should we catch up with the family on Saturday?',
+      }),
+    );
+
+    expect(result.category).toBe('personal');
+  });
+
+  it('trusts the provider spam label', () => {
+    const result = classifyThread(
+      makeThread({
+        subject: 'Normal-looking subject',
+        labels: [{ id: 'SPAM', name: 'SPAM' }],
+      }),
+    );
+
+    expect(result.category).toBe('spam');
+    expect(result.confidence).toBe(0.99);
+  });
+
+  it('returns none for weak or ambiguous messages', () => {
+    const result = classifyThread(makeThread({ subject: 'Quick note', body: 'Thanks.' }));
+
+    expect(result.category).toBe('none');
+    expect(result.labelName).toBeNull();
+  });
+});
+
+describe('applyAutoLabelClassification', () => {
+  it('creates a missing managed label and applies it through the provider-backed action', async () => {
+    let labels = [
+      {
+        id: 'finance-id',
+        name: 'Finance',
+        type: 'user',
+      },
+    ];
+    const applied: { threadId: string; add: string[]; remove: string[] }[] = [];
+    const agent: AutoLabelAgent = {
+      getUserLabels: async () => labels,
+      createLabel: async ({ name }) => {
+        labels = [...labels, { id: 'octg-id', name, type: 'user' }];
+      },
+      applyAutoLabel: async (threadId, add, remove) => {
+        applied.push({ threadId, add, remove });
+      },
+    };
+    const classification = classifyThread(
+      makeThread({
+        subject: 'OCTG inventory',
+        body: 'Please quote P110 casing.',
+      }),
+    );
+
+    const result = await applyAutoLabelClassification(agent, 'thread-1', classification, [
+      'finance-id',
+    ]);
+
+    expect(result.applied).toBe(true);
+    expect(applied).toEqual([
+      {
+        threadId: 'thread-1',
+        add: ['octg-id'],
+        remove: ['finance-id'],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a working first version of automatic email classification and labeling for Gmail-synced mail.

- classifies messages into OCTG, Tools/Newsletters, Personal, Finance, and spam using deterministic heuristics
- applies managed business labels during the incoming sync workflow
- trusts Gmail-confirmed spam while keeping heuristic spam classification manual for safety
- creates missing managed Gmail labels and updates both the provider and local cache
- exposes tRPC procedures to classify and apply labels manually
- adds a minimal `useAutoLabel` hook in `@zero/mail` for UI integration
- includes seven focused classifier tests

## Verification

- focused auto-labeling tests pass (7 tests)
- ESLint passes for the new files
- full package type checks still surface existing environment/generated-type errors; no feature-specific errors were found

## Remaining manual wiring

- add a settings control or feature flag before enabling auto-apply broadly
- tune category keywords and confidence thresholds against real mailbox data
- optionally wire an LLM provider and API key behind the classifier stub for ambiguous messages
- add an audit/history view for automatic label decisions
- place the mail hook in the desired visible message/thread UI

This pull request is intentionally not merged.